### PR TITLE
perf: reduce hot-path allocations in TakeLast, Zip, ReplaySubject and Subscriber

### DIFF
--- a/bench/benchmark_test.go
+++ b/bench/benchmark_test.go
@@ -12,24 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ro
-
-import (
-	"context"
-	"fmt"
-	"testing"
-)
-
-// The benchmarks below establish baselines for the per-event hot paths
+// Package bench contains performance benchmarks for the per-event hot paths
 // (Observer.Next, Subscriber.Next, operator chains, subjects) and for the
 // buffering operators. They are fully synchronous so that goleak stays happy.
 //
 // Run with:
 //
-//	go test -run='^$' -bench='^Benchmark' -count=10 -benchmem github.com/samber/ro
+//	go test -run='^$' -bench='^Benchmark' -count=10 -benchmem ./bench/
+package bench
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/samber/ro"
+)
 
 func BenchmarkObserverNext(b *testing.B) {
-	observer := NewObserver(
+	observer := ro.NewObserver(
 		func(value int) {},
 		func(err error) {},
 		func() {},
@@ -45,7 +46,7 @@ func BenchmarkObserverNext(b *testing.B) {
 
 func BenchmarkObserverNextWithContext(b *testing.B) {
 	ctx := context.Background()
-	observer := NewObserverWithContext(
+	observer := ro.NewObserverWithContext(
 		func(ctx context.Context, value int) {},
 		func(ctx context.Context, err error) {},
 		func(ctx context.Context) {},
@@ -62,17 +63,17 @@ func BenchmarkObserverNextWithContext(b *testing.B) {
 func BenchmarkSubscriberNext(b *testing.B) {
 	modes := []struct {
 		name string
-		mode ConcurrencyMode
+		mode ro.ConcurrencyMode
 	}{
-		{"safe", ConcurrencyModeSafe},
-		{"unsafe", ConcurrencyModeUnsafe},
-		{"eventually-safe", ConcurrencyModeEventuallySafe},
+		{"safe", ro.ConcurrencyModeSafe},
+		{"unsafe", ro.ConcurrencyModeUnsafe},
+		{"eventually-safe", ro.ConcurrencyModeEventuallySafe},
 	}
 
 	for _, m := range modes {
 		b.Run(m.name, func(b *testing.B) {
 			ctx := context.Background()
-			subscriber := NewSubscriberWithConcurrencyMode(NoopObserver[int](), m.mode)
+			subscriber := ro.NewSubscriberWithConcurrencyMode(ro.NoopObserver[int](), m.mode)
 
 			b.ReportAllocs()
 			b.ResetTimer()
@@ -86,15 +87,15 @@ func BenchmarkSubscriberNext(b *testing.B) {
 
 func BenchmarkPipeMapFilter(b *testing.B) {
 	ctx := context.Background()
-	subject := NewPublishSubject[int]()
+	subject := ro.NewPublishSubject[int]()
 
-	obs := Pipe2(
+	obs := ro.Pipe2(
 		subject.AsObservable(),
-		Map(func(v int) int { return v * 2 }),
-		Filter(func(v int) bool { return v%4 == 0 }),
+		ro.Map(func(v int) int { return v * 2 }),
+		ro.Filter(func(v int) bool { return v%4 == 0 }),
 	)
 
-	sub := obs.Subscribe(NoopObserver[int]())
+	sub := obs.Subscribe(ro.NoopObserver[int]())
 	defer sub.Unsubscribe()
 
 	b.ReportAllocs()
@@ -106,30 +107,30 @@ func BenchmarkPipeMapFilter(b *testing.B) {
 }
 
 func BenchmarkCollectRangePipe(b *testing.B) {
-	obs := Pipe2(
-		Range(0, 1000),
-		Map(func(v int64) int64 { return v * 2 }),
-		Filter(func(v int64) bool { return v%4 == 0 }),
+	obs := ro.Pipe2(
+		ro.Range(0, 1000),
+		ro.Map(func(v int64) int64 { return v * 2 }),
+		ro.Filter(func(v int64) bool { return v%4 == 0 }),
 	)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, _ = Collect(obs)
+		_, _ = ro.Collect(obs)
 	}
 }
 
 func BenchmarkTakeLast(b *testing.B) {
 	for _, count := range []int{8, 128} {
 		b.Run(fmt.Sprintf("count=%d", count), func(b *testing.B) {
-			obs := TakeLast[int64](count)(Range(0, 1024))
+			obs := ro.TakeLast[int64](count)(ro.Range(0, 1024))
 
 			b.ReportAllocs()
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				_, _ = Collect(obs)
+				_, _ = ro.Collect(obs)
 			}
 		})
 	}
@@ -138,37 +139,37 @@ func BenchmarkTakeLast(b *testing.B) {
 func BenchmarkSkipLast(b *testing.B) {
 	for _, count := range []int{8, 128} {
 		b.Run(fmt.Sprintf("count=%d", count), func(b *testing.B) {
-			obs := SkipLast[int64](count)(Range(0, 1024))
+			obs := ro.SkipLast[int64](count)(ro.Range(0, 1024))
 
 			b.ReportAllocs()
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				_, _ = Collect(obs)
+				_, _ = ro.Collect(obs)
 			}
 		})
 	}
 }
 
 func BenchmarkZip2(b *testing.B) {
-	obs := Zip2(Range(0, 256), Range(0, 256))
+	obs := ro.Zip2(ro.Range(0, 256), ro.Range(0, 256))
 
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, _ = Collect(obs)
+		_, _ = ro.Collect(obs)
 	}
 }
 
 func BenchmarkZipWith1(b *testing.B) {
-	obs := ZipWith1[int64](Range(0, 256))(Range(0, 256))
+	obs := ro.ZipWith1[int64](ro.Range(0, 256))(ro.Range(0, 256))
 
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, _ = Collect(obs)
+		_, _ = ro.Collect(obs)
 	}
 }
 
@@ -176,11 +177,11 @@ func BenchmarkPublishSubjectFanout(b *testing.B) {
 	for _, observers := range []int{1, 8, 64} {
 		b.Run(fmt.Sprintf("observers=%d", observers), func(b *testing.B) {
 			ctx := context.Background()
-			subject := NewPublishSubject[int]()
+			subject := ro.NewPublishSubject[int]()
 
-			subscriptions := make([]Subscription, 0, observers)
+			subscriptions := make([]ro.Subscription, 0, observers)
 			for range make([]struct{}, observers) {
-				subscriptions = append(subscriptions, subject.Subscribe(NoopObserver[int]()))
+				subscriptions = append(subscriptions, subject.Subscribe(ro.NoopObserver[int]()))
 			}
 			defer func() {
 				for _, sub := range subscriptions {
@@ -200,9 +201,9 @@ func BenchmarkPublishSubjectFanout(b *testing.B) {
 
 func BenchmarkReplaySubjectBounded(b *testing.B) {
 	ctx := context.Background()
-	subject := NewReplaySubject[int](16)
+	subject := ro.NewReplaySubject[int](16)
 
-	sub := subject.Subscribe(NoopObserver[int]())
+	sub := subject.Subscribe(ro.NoopObserver[int]())
 	defer sub.Unsubscribe()
 
 	b.ReportAllocs()
@@ -216,7 +217,7 @@ func BenchmarkReplaySubjectBounded(b *testing.B) {
 
 func BenchmarkReplaySubjectSubscribeReplay(b *testing.B) {
 	ctx := context.Background()
-	subject := NewReplaySubject[int](16)
+	subject := ro.NewReplaySubject[int](16)
 	for i := 0; i < 32; i++ {
 		subject.NextWithContext(ctx, i)
 	}
@@ -225,17 +226,17 @@ func BenchmarkReplaySubjectSubscribeReplay(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		subject.SubscribeWithContext(ctx, NoopObserver[int]()).Unsubscribe()
+		subject.SubscribeWithContext(ctx, ro.NoopObserver[int]()).Unsubscribe()
 	}
 }
 
 func BenchmarkDistinct(b *testing.B) {
 	ctx := context.Background()
-	subject := NewPublishSubject[int]()
+	subject := ro.NewPublishSubject[int]()
 
-	obs := Distinct[int]()(subject.AsObservable())
+	obs := ro.Distinct[int]()(subject.AsObservable())
 
-	sub := obs.Subscribe(NoopObserver[int]())
+	sub := obs.Subscribe(ro.NoopObserver[int]())
 	defer sub.Unsubscribe()
 
 	b.ReportAllocs()

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,247 @@
+// Copyright 2025 samber.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/samber/ro/blob/main/licenses/LICENSE.apache.md
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ro
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// The benchmarks below establish baselines for the per-event hot paths
+// (Observer.Next, Subscriber.Next, operator chains, subjects) and for the
+// buffering operators. They are fully synchronous so that goleak stays happy.
+//
+// Run with:
+//
+//	go test -run='^$' -bench='^Benchmark' -count=10 -benchmem github.com/samber/ro
+
+func BenchmarkObserverNext(b *testing.B) {
+	observer := NewObserver(
+		func(value int) {},
+		func(err error) {},
+		func() {},
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		observer.Next(i)
+	}
+}
+
+func BenchmarkObserverNextWithContext(b *testing.B) {
+	ctx := context.Background()
+	observer := NewObserverWithContext(
+		func(ctx context.Context, value int) {},
+		func(ctx context.Context, err error) {},
+		func(ctx context.Context) {},
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		observer.NextWithContext(ctx, i)
+	}
+}
+
+func BenchmarkSubscriberNext(b *testing.B) {
+	modes := []struct {
+		name string
+		mode ConcurrencyMode
+	}{
+		{"safe", ConcurrencyModeSafe},
+		{"unsafe", ConcurrencyModeUnsafe},
+		{"eventually-safe", ConcurrencyModeEventuallySafe},
+	}
+
+	for _, m := range modes {
+		b.Run(m.name, func(b *testing.B) {
+			ctx := context.Background()
+			subscriber := NewSubscriberWithConcurrencyMode(NoopObserver[int](), m.mode)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				subscriber.NextWithContext(ctx, i)
+			}
+		})
+	}
+}
+
+func BenchmarkPipeMapFilter(b *testing.B) {
+	ctx := context.Background()
+	subject := NewPublishSubject[int]()
+
+	obs := Pipe2(
+		subject.AsObservable(),
+		Map(func(v int) int { return v * 2 }),
+		Filter(func(v int) bool { return v%4 == 0 }),
+	)
+
+	sub := obs.Subscribe(NoopObserver[int]())
+	defer sub.Unsubscribe()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		subject.NextWithContext(ctx, i)
+	}
+}
+
+func BenchmarkCollectRangePipe(b *testing.B) {
+	obs := Pipe2(
+		Range(0, 1000),
+		Map(func(v int64) int64 { return v * 2 }),
+		Filter(func(v int64) bool { return v%4 == 0 }),
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = Collect(obs)
+	}
+}
+
+func BenchmarkTakeLast(b *testing.B) {
+	for _, count := range []int{8, 128} {
+		b.Run(fmt.Sprintf("count=%d", count), func(b *testing.B) {
+			obs := TakeLast[int64](count)(Range(0, 1024))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				_, _ = Collect(obs)
+			}
+		})
+	}
+}
+
+func BenchmarkSkipLast(b *testing.B) {
+	for _, count := range []int{8, 128} {
+		b.Run(fmt.Sprintf("count=%d", count), func(b *testing.B) {
+			obs := SkipLast[int64](count)(Range(0, 1024))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				_, _ = Collect(obs)
+			}
+		})
+	}
+}
+
+func BenchmarkZip2(b *testing.B) {
+	obs := Zip2(Range(0, 256), Range(0, 256))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = Collect(obs)
+	}
+}
+
+func BenchmarkZipWith1(b *testing.B) {
+	obs := ZipWith1[int64](Range(0, 256))(Range(0, 256))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = Collect(obs)
+	}
+}
+
+func BenchmarkPublishSubjectFanout(b *testing.B) {
+	for _, observers := range []int{1, 8, 64} {
+		b.Run(fmt.Sprintf("observers=%d", observers), func(b *testing.B) {
+			ctx := context.Background()
+			subject := NewPublishSubject[int]()
+
+			subscriptions := make([]Subscription, 0, observers)
+			for range make([]struct{}, observers) {
+				subscriptions = append(subscriptions, subject.Subscribe(NoopObserver[int]()))
+			}
+			defer func() {
+				for _, sub := range subscriptions {
+					sub.Unsubscribe()
+				}
+			}()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				subject.NextWithContext(ctx, i)
+			}
+		})
+	}
+}
+
+func BenchmarkReplaySubjectBounded(b *testing.B) {
+	ctx := context.Background()
+	subject := NewReplaySubject[int](16)
+
+	sub := subject.Subscribe(NoopObserver[int]())
+	defer sub.Unsubscribe()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	// Steady state: the buffer is full and every Next drops the oldest value.
+	for i := 0; i < b.N; i++ {
+		subject.NextWithContext(ctx, i)
+	}
+}
+
+func BenchmarkReplaySubjectSubscribeReplay(b *testing.B) {
+	ctx := context.Background()
+	subject := NewReplaySubject[int](16)
+	for i := 0; i < 32; i++ {
+		subject.NextWithContext(ctx, i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		subject.SubscribeWithContext(ctx, NoopObserver[int]()).Unsubscribe()
+	}
+}
+
+func BenchmarkDistinct(b *testing.B) {
+	ctx := context.Background()
+	subject := NewPublishSubject[int]()
+
+	obs := Distinct[int]()(subject.AsObservable())
+
+	sub := obs.Subscribe(NoopObserver[int]())
+	defer sub.Unsubscribe()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		subject.NextWithContext(ctx, i%1024)
+	}
+}

--- a/internal/xqueue/queue.go
+++ b/internal/xqueue/queue.go
@@ -1,0 +1,59 @@
+// Copyright 2025 samber.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/samber/ro/blob/main/licenses/LICENSE.apache.md
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xqueue
+
+// Queue is a FIFO queue backed by a slice. Popped slots are zeroed so that
+// dequeued values are not pinned in memory, and the backing array is reused
+// once the queue is drained, so a balanced push/pop workload does not
+// allocate in steady state.
+//
+// Queue is not safe for concurrent use.
+type Queue[T any] struct {
+	items []T
+	head  int
+}
+
+// Push appends a value to the back of the queue.
+func (q *Queue[T]) Push(value T) {
+	q.items = append(q.items, value)
+}
+
+// Pop removes and returns the value at the front of the queue.
+// It panics if the queue is empty.
+func (q *Queue[T]) Pop() T {
+	value := q.items[q.head]
+
+	var zero T
+	q.items[q.head] = zero
+	q.head++
+
+	if q.head == len(q.items) {
+		q.items = q.items[:0]
+		q.head = 0
+	}
+
+	return value
+}
+
+// Len returns the number of values in the queue.
+func (q *Queue[T]) Len() int {
+	return len(q.items) - q.head
+}
+
+// Reset empties the queue and releases the backing array.
+func (q *Queue[T]) Reset() {
+	q.items = nil
+	q.head = 0
+}

--- a/internal/xqueue/queue.go
+++ b/internal/xqueue/queue.go
@@ -36,6 +36,11 @@ type Queue[T any] interface {
 
 var _ Queue[int] = (*queueImpl[int])(nil)
 
+// minShrinkCap is the smallest backing array the queue will shrink down to.
+// Below it, the savings are not worth the reallocation, and keeping a small
+// floor avoids thrashing for queues that hover near empty.
+const minShrinkCap = 16
+
 // NewQueue creates a new empty FIFO queue.
 func NewQueue[T any]() Queue[T] {
 	return &queueImpl[T]{}
@@ -52,7 +57,12 @@ type queueImpl[T any] struct {
 // Push appends a value to the back of the queue.
 func (q *queueImpl[T]) Push(value T) {
 	if q.count == len(q.items) {
-		q.grow()
+		newCap := len(q.items) * 2
+		if newCap == 0 {
+			newCap = 4
+		}
+
+		q.resize(newCap)
 	}
 
 	q.items[q.tail] = value
@@ -84,6 +94,15 @@ func (q *queueImpl[T]) Pop() T {
 
 	q.count--
 
+	// Release backing storage in a single step once a large array has drained
+	// down to a handful of items, so a queue that grew for a burst does not
+	// hold the peak array after the producer goes quiet. Shrinking only at a
+	// low absolute count (rather than progressively while draining) keeps a
+	// full drain to one reallocation, and the floor avoids thrashing.
+	if q.count <= minShrinkCap && len(q.items) > 2*minShrinkCap {
+		q.resize(minShrinkCap)
+	}
+
 	return value
 }
 
@@ -100,14 +119,9 @@ func (q *queueImpl[T]) Reset() {
 	q.count = 0
 }
 
-// grow doubles the backing array and re-linearizes the live region so that it
-// starts at index 0.
-func (q *queueImpl[T]) grow() {
-	newCap := len(q.items) * 2
-	if newCap == 0 {
-		newCap = 4
-	}
-
+// resize moves the live region into a freshly allocated array of newCap,
+// re-linearizing it so that it starts at index 0. newCap must be >= count.
+func (q *queueImpl[T]) resize(newCap int) {
 	buf := make([]T, newCap)
 
 	// Copy the live region in order, starting from head and wrapping around.
@@ -117,4 +131,7 @@ func (q *queueImpl[T]) grow() {
 	q.items = buf
 	q.head = 0
 	q.tail = q.count
+	if q.tail == newCap {
+		q.tail = 0
+	}
 }

--- a/internal/xqueue/queue.go
+++ b/internal/xqueue/queue.go
@@ -14,46 +14,87 @@
 
 package xqueue
 
-// Queue is a FIFO queue backed by a slice. Popped slots are zeroed so that
-// dequeued values are not pinned in memory, and the backing array is reused
-// once the queue is drained, so a balanced push/pop workload does not
-// allocate in steady state.
+// Queue is a FIFO queue backed by a growable ring buffer. Popped slots are
+// zeroed so that dequeued values are not pinned in memory, and the backing
+// array is reused in place: a balanced push/pop workload does not allocate in
+// steady state, and a sustained imbalance (one producer permanently ahead of
+// the consumer) keeps the buffer bounded to the peak depth rather than letting
+// a dead prefix grow without bound.
 //
 // Queue is not safe for concurrent use.
 type Queue[T any] struct {
 	items []T
 	head  int
+	tail  int
+	count int
 }
 
 // Push appends a value to the back of the queue.
 func (q *Queue[T]) Push(value T) {
-	q.items = append(q.items, value)
+	if q.count == len(q.items) {
+		q.grow()
+	}
+
+	q.items[q.tail] = value
+
+	q.tail++
+	if q.tail == len(q.items) {
+		q.tail = 0
+	}
+
+	q.count++
 }
 
 // Pop removes and returns the value at the front of the queue.
 // It panics if the queue is empty.
 func (q *Queue[T]) Pop() T {
+	if q.count == 0 {
+		panic("xqueue: Pop from empty queue")
+	}
+
 	value := q.items[q.head]
 
 	var zero T
 	q.items[q.head] = zero
-	q.head++
 
+	q.head++
 	if q.head == len(q.items) {
-		q.items = q.items[:0]
 		q.head = 0
 	}
+
+	q.count--
 
 	return value
 }
 
 // Len returns the number of values in the queue.
 func (q *Queue[T]) Len() int {
-	return len(q.items) - q.head
+	return q.count
 }
 
 // Reset empties the queue and releases the backing array.
 func (q *Queue[T]) Reset() {
 	q.items = nil
 	q.head = 0
+	q.tail = 0
+	q.count = 0
+}
+
+// grow doubles the backing array and re-linearizes the live region so that it
+// starts at index 0.
+func (q *Queue[T]) grow() {
+	newCap := len(q.items) * 2
+	if newCap == 0 {
+		newCap = 4
+	}
+
+	buf := make([]T, newCap)
+
+	// Copy the live region in order, starting from head and wrapping around.
+	n := copy(buf, q.items[q.head:])
+	copy(buf[n:], q.items[:q.tail])
+
+	q.items = buf
+	q.head = 0
+	q.tail = q.count
 }

--- a/internal/xqueue/queue.go
+++ b/internal/xqueue/queue.go
@@ -14,15 +14,35 @@
 
 package xqueue
 
-// Queue is a FIFO queue backed by a growable ring buffer. Popped slots are
-// zeroed so that dequeued values are not pinned in memory, and the backing
-// array is reused in place: a balanced push/pop workload does not allocate in
-// steady state, and a sustained imbalance (one producer permanently ahead of
-// the consumer) keeps the buffer bounded to the peak depth rather than letting
-// a dead prefix grow without bound.
+// Queue is a FIFO queue. Popped slots are zeroed so that dequeued values are
+// not pinned in memory, and the backing storage is reused in place: a balanced
+// push/pop workload does not allocate in steady state, and a sustained
+// imbalance (one producer permanently ahead of the consumer) keeps the storage
+// bounded to the peak depth rather than letting a dead prefix grow without
+// bound.
 //
 // Queue is not safe for concurrent use.
-type Queue[T any] struct {
+type Queue[T any] interface {
+	// Push appends a value to the back of the queue.
+	Push(value T)
+	// Pop removes and returns the value at the front of the queue.
+	// It panics if the queue is empty.
+	Pop() T
+	// Len returns the number of values in the queue.
+	Len() int
+	// Reset empties the queue and releases the backing storage.
+	Reset()
+}
+
+var _ Queue[int] = (*queueImpl[int])(nil)
+
+// NewQueue creates a new empty FIFO queue.
+func NewQueue[T any]() Queue[T] {
+	return &queueImpl[T]{}
+}
+
+// queueImpl is a FIFO queue backed by a growable ring buffer.
+type queueImpl[T any] struct {
 	items []T
 	head  int
 	tail  int
@@ -30,7 +50,7 @@ type Queue[T any] struct {
 }
 
 // Push appends a value to the back of the queue.
-func (q *Queue[T]) Push(value T) {
+func (q *queueImpl[T]) Push(value T) {
 	if q.count == len(q.items) {
 		q.grow()
 	}
@@ -47,7 +67,7 @@ func (q *Queue[T]) Push(value T) {
 
 // Pop removes and returns the value at the front of the queue.
 // It panics if the queue is empty.
-func (q *Queue[T]) Pop() T {
+func (q *queueImpl[T]) Pop() T {
 	if q.count == 0 {
 		panic("xqueue: Pop from empty queue")
 	}
@@ -68,12 +88,12 @@ func (q *Queue[T]) Pop() T {
 }
 
 // Len returns the number of values in the queue.
-func (q *Queue[T]) Len() int {
+func (q *queueImpl[T]) Len() int {
 	return q.count
 }
 
 // Reset empties the queue and releases the backing array.
-func (q *Queue[T]) Reset() {
+func (q *queueImpl[T]) Reset() {
 	q.items = nil
 	q.head = 0
 	q.tail = 0
@@ -82,7 +102,7 @@ func (q *Queue[T]) Reset() {
 
 // grow doubles the backing array and re-linearizes the live region so that it
 // starts at index 0.
-func (q *Queue[T]) grow() {
+func (q *queueImpl[T]) grow() {
 	newCap := len(q.items) * 2
 	if newCap == 0 {
 		newCap = 4

--- a/internal/xqueue/queue_test.go
+++ b/internal/xqueue/queue_test.go
@@ -60,6 +60,27 @@ func TestQueueReusesCapacityWhenDrained(t *testing.T) {
 	is.Equal(0.0, allocs)
 }
 
+func TestQueueBoundedUnderSustainedSkew(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	// One producer permanently ahead of the consumer: the live depth stays
+	// constant but head keeps advancing. The backing array must stay bounded
+	// to the peak depth rather than growing without bound.
+	var q Queue[int]
+	for i := 0; i < 8; i++ {
+		q.Push(i)
+	}
+
+	for i := 0; i < 100_000; i++ {
+		q.Push(i)
+		_ = q.Pop()
+	}
+
+	is.Equal(8, q.Len())
+	is.LessOrEqual(cap(q.items), 16)
+}
+
 func TestQueuePopEmptyPanics(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)

--- a/internal/xqueue/queue_test.go
+++ b/internal/xqueue/queue_test.go
@@ -44,7 +44,8 @@ func TestQueuePushPop(t *testing.T) {
 }
 
 func TestQueueReusesCapacityWhenDrained(t *testing.T) {
-	t.Parallel()
+	// Not parallel: testing.AllocsPerRun is unreliable when other tests run
+	// concurrently, since its result depends on whole-program GC behavior.
 	is := assert.New(t)
 
 	q := NewQueue[int]()

--- a/internal/xqueue/queue_test.go
+++ b/internal/xqueue/queue_test.go
@@ -1,0 +1,135 @@
+// Copyright 2025 samber.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/samber/ro/blob/main/licenses/LICENSE.apache.md
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xqueue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueuePushPop(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	var q Queue[int]
+
+	is.Equal(0, q.Len())
+
+	q.Push(1)
+	q.Push(2)
+	q.Push(3)
+	is.Equal(3, q.Len())
+
+	is.Equal(1, q.Pop())
+	is.Equal(2, q.Pop())
+	is.Equal(1, q.Len())
+
+	q.Push(4)
+	is.Equal(3, q.Pop())
+	is.Equal(4, q.Pop())
+	is.Equal(0, q.Len())
+}
+
+func TestQueueReusesCapacityWhenDrained(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	var q Queue[int]
+
+	// Warm up the backing array.
+	q.Push(1)
+	q.Pop()
+
+	allocs := testing.AllocsPerRun(100, func() {
+		q.Push(1)
+		q.Pop()
+	})
+	is.Equal(0.0, allocs)
+}
+
+func TestQueuePopEmptyPanics(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	var q Queue[int]
+
+	is.Panics(func() {
+		q.Pop()
+	})
+}
+
+func TestQueueZeroesPoppedSlots(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	var q Queue[*int]
+
+	v1 := 1
+	v2 := 2
+	q.Push(&v1)
+	q.Push(&v2)
+	is.Equal(&v1, q.Pop())
+
+	// The popped slot must not pin the value.
+	is.Nil(q.items[0])
+	is.Equal(&v2, q.Pop())
+}
+
+func TestQueueReset(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	var q Queue[int]
+
+	q.Push(1)
+	q.Push(2)
+	q.Pop()
+	q.Reset()
+
+	is.Equal(0, q.Len())
+	is.Nil(q.items)
+	is.Equal(0, q.head)
+
+	q.Push(3)
+	is.Equal(3, q.Pop())
+}
+
+func TestQueueInterleaved(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	var q Queue[int]
+
+	next := 0
+	expected := 0
+
+	for i := 0; i < 1000; i++ {
+		q.Push(next)
+		next++
+
+		if i%3 == 0 {
+			is.Equal(expected, q.Pop())
+			expected++
+		}
+	}
+
+	for q.Len() > 0 {
+		is.Equal(expected, q.Pop())
+		expected++
+	}
+
+	is.Equal(next, expected)
+}

--- a/internal/xqueue/queue_test.go
+++ b/internal/xqueue/queue_test.go
@@ -24,7 +24,7 @@ func TestQueuePushPop(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	var q Queue[int]
+	q := NewQueue[int]()
 
 	is.Equal(0, q.Len())
 
@@ -47,7 +47,7 @@ func TestQueueReusesCapacityWhenDrained(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	var q Queue[int]
+	q := NewQueue[int]()
 
 	// Warm up the backing array.
 	q.Push(1)
@@ -67,7 +67,7 @@ func TestQueueBoundedUnderSustainedSkew(t *testing.T) {
 	// One producer permanently ahead of the consumer: the live depth stays
 	// constant but head keeps advancing. The backing array must stay bounded
 	// to the peak depth rather than growing without bound.
-	var q Queue[int]
+	q := &queueImpl[int]{}
 	for i := 0; i < 8; i++ {
 		q.Push(i)
 	}
@@ -85,7 +85,7 @@ func TestQueuePopEmptyPanics(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	var q Queue[int]
+	q := NewQueue[int]()
 
 	is.Panics(func() {
 		q.Pop()
@@ -96,7 +96,7 @@ func TestQueueZeroesPoppedSlots(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	var q Queue[*int]
+	q := &queueImpl[*int]{}
 
 	v1 := 1
 	v2 := 2
@@ -113,7 +113,7 @@ func TestQueueReset(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	var q Queue[int]
+	q := &queueImpl[int]{}
 
 	q.Push(1)
 	q.Push(2)
@@ -132,7 +132,7 @@ func TestQueueInterleaved(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	var q Queue[int]
+	q := NewQueue[int]()
 
 	next := 0
 	expected := 0

--- a/internal/xqueue/queue_test.go
+++ b/internal/xqueue/queue_test.go
@@ -81,6 +81,31 @@ func TestQueueBoundedUnderSustainedSkew(t *testing.T) {
 	is.LessOrEqual(cap(q.items), 16)
 }
 
+func TestQueueShrinksAfterBurst(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	q := &queueImpl[int]{}
+
+	// Grow the backing array with a burst.
+	for i := 0; i < 256; i++ {
+		q.Push(i)
+	}
+	is.GreaterOrEqual(cap(q.items), 256)
+
+	// Drain back down to a single live value: the backing array must be
+	// released rather than held at the peak. A small floor is acceptable.
+	for q.Len() > 1 {
+		_ = q.Pop()
+	}
+	is.Equal(1, q.Len())
+	is.LessOrEqual(cap(q.items), minShrinkCap)
+
+	// The retained value is still correct and in order.
+	is.Equal(255, q.Pop())
+	is.Equal(0, q.Len())
+}
+
 func TestQueuePopEmptyPanics(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)

--- a/operator_combining.go
+++ b/operator_combining.go
@@ -1098,7 +1098,7 @@ type zipDestination interface {
 	CompleteWithContext(context.Context)
 }
 
-// This code is dity but much more concise than the original implementation.
+// This code is dirty but much more concise than the original implementation.
 func zipInnerSubscription[T any](subscriberCtx context.Context, obs Observable[T], mu *sync.Mutex, values *xqueue.Queue[T], completed *bool, onUpdate func(context.Context), destination zipDestination, subscriptions Subscription) {
 	subscriptions.AddUnsubscribable(
 		obs.SubscribeWithContext(

--- a/operator_combining.go
+++ b/operator_combining.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/samber/ro/internal/xatomic"
+	"github.com/samber/ro/internal/xqueue"
 )
 
 // MergeWith merges the values from all observables to a single observable result.
@@ -1098,7 +1099,7 @@ type zipDestination interface {
 }
 
 // This code is dity but much more concise than the original implementation.
-func zipInnerSubscription[T any](subscriberCtx context.Context, obs Observable[T], mu *sync.Mutex, values *[]*T, completed *bool, onUpdate func(context.Context), destination zipDestination, subscriptions Subscription) {
+func zipInnerSubscription[T any](subscriberCtx context.Context, obs Observable[T], mu *sync.Mutex, values *xqueue.Queue[T], completed *bool, onUpdate func(context.Context), destination zipDestination, subscriptions Subscription) {
 	subscriptions.AddUnsubscribable(
 		obs.SubscribeWithContext(
 			subscriberCtx,
@@ -1106,7 +1107,7 @@ func zipInnerSubscription[T any](subscriberCtx context.Context, obs Observable[T
 				func(ctx context.Context, v T) {
 					mu.Lock()
 
-					*values = append(*values, &v)
+					values.Push(v)
 
 					mu.Unlock()
 
@@ -1127,7 +1128,7 @@ func zipInnerSubscription[T any](subscriberCtx context.Context, obs Observable[T
 
 					*completed = true
 
-					if len(*values) == 0 {
+					if values.Len() == 0 {
 						mu.Unlock()
 						destination.CompleteWithContext(ctx)
 					} else {
@@ -1161,8 +1162,8 @@ func ZipWith1[A, B any](obsB Observable[B]) func(Observable[A]) Observable[lo.Tu
 		return NewObservableWithContext(func(subscriberCtx context.Context, destination Observer[lo.Tuple2[A, B]]) Teardown {
 			var mu sync.Mutex
 
-			var valueA []*A
-			var valueB []*B
+			var valueA xqueue.Queue[A]
+			var valueB xqueue.Queue[B]
 
 			var completedA bool
 			var completedB bool
@@ -1170,20 +1171,18 @@ func ZipWith1[A, B any](obsB Observable[B]) func(Observable[A]) Observable[lo.Tu
 			onUpdate := func(ctx context.Context) {
 				mu.Lock()
 
-				if len(valueA) > 0 && len(valueB) > 0 {
-					a := valueA[0]
-					b := valueB[0]
-					valueA = valueA[1:]
-					valueB = valueB[1:]
+				if valueA.Len() > 0 && valueB.Len() > 0 {
+					a := valueA.Pop()
+					b := valueB.Pop()
 
 					mu.Unlock() // unlock before calling destination.Next to prevent long locks
 
-					destination.NextWithContext(ctx, lo.T2(*a, *b)) // @TODO: Send the last context ?
+					destination.NextWithContext(ctx, lo.T2(a, b)) // @TODO: Send the last context ?
 
 					mu.Lock()
 
-					if (completedA && len(valueA) == 0) ||
-						(completedB && len(valueB) == 0) {
+					if (completedA && valueA.Len() == 0) ||
+						(completedB && valueB.Len() == 0) {
 						destination.CompleteWithContext(ctx) // @TODO: Send the last context ?
 					}
 				}
@@ -1203,8 +1202,8 @@ func ZipWith1[A, B any](obsB Observable[B]) func(Observable[A]) Observable[lo.Tu
 
 				completedA = true
 				completedB = true
-				valueA = nil
-				valueB = nil
+				valueA.Reset()
+				valueB.Reset()
 
 				mu.Unlock()
 			}
@@ -1223,9 +1222,9 @@ func ZipWith2[A, B, C any](obsB Observable[B], obsC Observable[C]) func(Observab
 		return NewObservableWithContext(func(subscriberCtx context.Context, destination Observer[lo.Tuple3[A, B, C]]) Teardown {
 			var mu sync.Mutex
 
-			var valueA []*A
-			var valueB []*B
-			var valueC []*C
+			var valueA xqueue.Queue[A]
+			var valueB xqueue.Queue[B]
+			var valueC xqueue.Queue[C]
 
 			var completedA bool
 			var completedB bool
@@ -1234,23 +1233,20 @@ func ZipWith2[A, B, C any](obsB Observable[B], obsC Observable[C]) func(Observab
 			onUpdate := func(ctx context.Context) {
 				mu.Lock()
 
-				if len(valueA) > 0 && len(valueB) > 0 && len(valueC) > 0 {
-					a := valueA[0]
-					b := valueB[0]
-					c := valueC[0]
-					valueA = valueA[1:]
-					valueB = valueB[1:]
-					valueC = valueC[1:]
+				if valueA.Len() > 0 && valueB.Len() > 0 && valueC.Len() > 0 {
+					a := valueA.Pop()
+					b := valueB.Pop()
+					c := valueC.Pop()
 
 					mu.Unlock() // unlock before calling destination.Next to prevent long locks
 
-					destination.NextWithContext(ctx, lo.T3(*a, *b, *c)) // @TODO: Send the last context ?
+					destination.NextWithContext(ctx, lo.T3(a, b, c)) // @TODO: Send the last context ?
 
 					mu.Lock()
 
-					if (completedA && len(valueA) == 0) ||
-						(completedB && len(valueB) == 0) ||
-						(completedC && len(valueC) == 0) {
+					if (completedA && valueA.Len() == 0) ||
+						(completedB && valueB.Len() == 0) ||
+						(completedC && valueC.Len() == 0) {
 						destination.CompleteWithContext(ctx) // @TODO: Send the last context ?
 					}
 				}
@@ -1272,9 +1268,9 @@ func ZipWith2[A, B, C any](obsB Observable[B], obsC Observable[C]) func(Observab
 				completedA = true
 				completedB = true
 				completedC = true
-				valueA = nil
-				valueB = nil
-				valueC = nil
+				valueA.Reset()
+				valueB.Reset()
+				valueC.Reset()
 
 				mu.Unlock()
 			}
@@ -1292,10 +1288,10 @@ func ZipWith3[A, B, C, D any](obsB Observable[B], obsC Observable[C], obsD Obser
 		return NewObservableWithContext(func(subscriberCtx context.Context, destination Observer[lo.Tuple4[A, B, C, D]]) Teardown {
 			var mu sync.Mutex
 
-			var valueA []*A
-			var valueB []*B
-			var valueC []*C
-			var valueD []*D
+			var valueA xqueue.Queue[A]
+			var valueB xqueue.Queue[B]
+			var valueC xqueue.Queue[C]
+			var valueD xqueue.Queue[D]
 
 			var completedA bool
 			var completedB bool
@@ -1305,26 +1301,22 @@ func ZipWith3[A, B, C, D any](obsB Observable[B], obsC Observable[C], obsD Obser
 			onUpdate := func(ctx context.Context) {
 				mu.Lock()
 
-				if len(valueA) > 0 && len(valueB) > 0 && len(valueC) > 0 && len(valueD) > 0 {
-					a := valueA[0]
-					b := valueB[0]
-					c := valueC[0]
-					d := valueD[0]
-					valueA = valueA[1:]
-					valueB = valueB[1:]
-					valueC = valueC[1:]
-					valueD = valueD[1:]
+				if valueA.Len() > 0 && valueB.Len() > 0 && valueC.Len() > 0 && valueD.Len() > 0 {
+					a := valueA.Pop()
+					b := valueB.Pop()
+					c := valueC.Pop()
+					d := valueD.Pop()
 
 					mu.Unlock() // unlock before calling destination.Next to prevent long locks
 
-					destination.NextWithContext(ctx, lo.T4(*a, *b, *c, *d)) // @TODO: Send the last context ?
+					destination.NextWithContext(ctx, lo.T4(a, b, c, d)) // @TODO: Send the last context ?
 
 					mu.Lock()
 
-					if (completedA && len(valueA) == 0) ||
-						(completedB && len(valueB) == 0) ||
-						(completedC && len(valueC) == 0) ||
-						(completedD && len(valueD) == 0) {
+					if (completedA && valueA.Len() == 0) ||
+						(completedB && valueB.Len() == 0) ||
+						(completedC && valueC.Len() == 0) ||
+						(completedD && valueD.Len() == 0) {
 						destination.CompleteWithContext(ctx) // @TODO: Send the last context ?
 					}
 				}
@@ -1348,10 +1340,10 @@ func ZipWith3[A, B, C, D any](obsB Observable[B], obsC Observable[C], obsD Obser
 				completedB = true
 				completedC = true
 				completedD = true
-				valueA = nil
-				valueB = nil
-				valueC = nil
-				valueD = nil
+				valueA.Reset()
+				valueB.Reset()
+				valueC.Reset()
+				valueD.Reset()
 
 				mu.Unlock()
 			}
@@ -1369,11 +1361,11 @@ func ZipWith4[A, B, C, D, E any](obsB Observable[B], obsC Observable[C], obsD Ob
 		return NewObservableWithContext(func(subscriberCtx context.Context, destination Observer[lo.Tuple5[A, B, C, D, E]]) Teardown {
 			var mu sync.Mutex
 
-			var valueA []*A
-			var valueB []*B
-			var valueC []*C
-			var valueD []*D
-			var valueE []*E
+			var valueA xqueue.Queue[A]
+			var valueB xqueue.Queue[B]
+			var valueC xqueue.Queue[C]
+			var valueD xqueue.Queue[D]
+			var valueE xqueue.Queue[E]
 
 			var completedA bool
 			var completedB bool
@@ -1384,29 +1376,24 @@ func ZipWith4[A, B, C, D, E any](obsB Observable[B], obsC Observable[C], obsD Ob
 			onUpdate := func(ctx context.Context) {
 				mu.Lock()
 
-				if len(valueA) > 0 && len(valueB) > 0 && len(valueC) > 0 && len(valueD) > 0 && len(valueE) > 0 {
-					a := valueA[0]
-					b := valueB[0]
-					c := valueC[0]
-					d := valueD[0]
-					e := valueE[0]
-					valueA = valueA[1:]
-					valueB = valueB[1:]
-					valueC = valueC[1:]
-					valueD = valueD[1:]
-					valueE = valueE[1:]
+				if valueA.Len() > 0 && valueB.Len() > 0 && valueC.Len() > 0 && valueD.Len() > 0 && valueE.Len() > 0 {
+					a := valueA.Pop()
+					b := valueB.Pop()
+					c := valueC.Pop()
+					d := valueD.Pop()
+					e := valueE.Pop()
 
 					mu.Unlock() // unlock before calling destination.Next to prevent long locks
 
-					destination.NextWithContext(ctx, lo.T5(*a, *b, *c, *d, *e)) // @TODO: Send the last context ?
+					destination.NextWithContext(ctx, lo.T5(a, b, c, d, e)) // @TODO: Send the last context ?
 
 					mu.Lock()
 
-					if (completedA && len(valueA) == 0) ||
-						(completedB && len(valueB) == 0) ||
-						(completedC && len(valueC) == 0) ||
-						(completedD && len(valueD) == 0) ||
-						(completedE && len(valueE) == 0) {
+					if (completedA && valueA.Len() == 0) ||
+						(completedB && valueB.Len() == 0) ||
+						(completedC && valueC.Len() == 0) ||
+						(completedD && valueD.Len() == 0) ||
+						(completedE && valueE.Len() == 0) {
 						destination.CompleteWithContext(ctx) // @TODO: Send the last context ?
 					}
 				}
@@ -1432,11 +1419,11 @@ func ZipWith4[A, B, C, D, E any](obsB Observable[B], obsC Observable[C], obsD Ob
 				completedC = true
 				completedD = true
 				completedE = true
-				valueA = nil
-				valueB = nil
-				valueC = nil
-				valueD = nil
-				valueE = nil
+				valueA.Reset()
+				valueB.Reset()
+				valueC.Reset()
+				valueD.Reset()
+				valueE.Reset()
 
 				mu.Unlock()
 			}
@@ -1455,12 +1442,12 @@ func ZipWith5[A, B, C, D, E, F any](obsB Observable[B], obsC Observable[C], obsD
 		return NewObservableWithContext(func(subscriberCtx context.Context, destination Observer[lo.Tuple6[A, B, C, D, E, F]]) Teardown {
 			var mu sync.Mutex
 
-			var valueA []*A
-			var valueB []*B
-			var valueC []*C
-			var valueD []*D
-			var valueE []*E
-			var valueF []*F
+			var valueA xqueue.Queue[A]
+			var valueB xqueue.Queue[B]
+			var valueC xqueue.Queue[C]
+			var valueD xqueue.Queue[D]
+			var valueE xqueue.Queue[E]
+			var valueF xqueue.Queue[F]
 
 			var completedA bool
 			var completedB bool
@@ -1472,32 +1459,26 @@ func ZipWith5[A, B, C, D, E, F any](obsB Observable[B], obsC Observable[C], obsD
 			onUpdate := func(ctx context.Context) {
 				mu.Lock()
 
-				if len(valueA) > 0 && len(valueB) > 0 && len(valueC) > 0 && len(valueD) > 0 && len(valueE) > 0 && len(valueF) > 0 {
-					a := valueA[0]
-					b := valueB[0]
-					c := valueC[0]
-					d := valueD[0]
-					e := valueE[0]
-					f := valueF[0]
-					valueA = valueA[1:]
-					valueB = valueB[1:]
-					valueC = valueC[1:]
-					valueD = valueD[1:]
-					valueE = valueE[1:]
-					valueF = valueF[1:]
+				if valueA.Len() > 0 && valueB.Len() > 0 && valueC.Len() > 0 && valueD.Len() > 0 && valueE.Len() > 0 && valueF.Len() > 0 {
+					a := valueA.Pop()
+					b := valueB.Pop()
+					c := valueC.Pop()
+					d := valueD.Pop()
+					e := valueE.Pop()
+					f := valueF.Pop()
 
 					mu.Unlock() // unlock before calling destination.Next to prevent long locks
 
-					destination.NextWithContext(ctx, lo.T6(*a, *b, *c, *d, *e, *f)) // @TODO: Send the last context ?
+					destination.NextWithContext(ctx, lo.T6(a, b, c, d, e, f)) // @TODO: Send the last context ?
 
 					mu.Lock()
 
-					if (completedA && len(valueA) == 0) ||
-						(completedB && len(valueB) == 0) ||
-						(completedC && len(valueC) == 0) ||
-						(completedD && len(valueD) == 0) ||
-						(completedE && len(valueE) == 0) ||
-						(completedF && len(valueF) == 0) {
+					if (completedA && valueA.Len() == 0) ||
+						(completedB && valueB.Len() == 0) ||
+						(completedC && valueC.Len() == 0) ||
+						(completedD && valueD.Len() == 0) ||
+						(completedE && valueE.Len() == 0) ||
+						(completedF && valueF.Len() == 0) {
 						destination.CompleteWithContext(ctx) // @TODO: Send the last context ?
 					}
 				}
@@ -1525,12 +1506,12 @@ func ZipWith5[A, B, C, D, E, F any](obsB Observable[B], obsC Observable[C], obsD
 				completedD = true
 				completedE = true
 				completedF = true
-				valueA = nil
-				valueB = nil
-				valueC = nil
-				valueD = nil
-				valueE = nil
-				valueF = nil
+				valueA.Reset()
+				valueB.Reset()
+				valueC.Reset()
+				valueD.Reset()
+				valueE.Reset()
+				valueF.Reset()
 
 				mu.Unlock()
 			}
@@ -1541,7 +1522,7 @@ func ZipWith5[A, B, C, D, E, F any](obsB Observable[B], obsC Observable[C], obsD
 func zipAllInnerSubscriptions[T any](outerCtx context.Context, sources []Observable[T], destination Observer[[]T]) Teardown {
 	var mu sync.Mutex
 
-	values := make([][]*T, len(sources))
+	values := make([]xqueue.Queue[T], len(sources))
 	completed := make([]bool, len(sources))
 
 	onUpdate := func(ctx context.Context) {
@@ -1550,7 +1531,7 @@ func zipAllInnerSubscriptions[T any](outerCtx context.Context, sources []Observa
 		hasEmptyQueue := false
 
 		for i := range sources {
-			if len(values[i]) == 0 {
+			if values[i].Len() == 0 {
 				hasEmptyQueue = true
 				break
 			}
@@ -1559,8 +1540,7 @@ func zipAllInnerSubscriptions[T any](outerCtx context.Context, sources []Observa
 		if !hasEmptyQueue {
 			result := make([]T, len(sources))
 			for i := range sources {
-				result[i] = *values[i][0]
-				values[i] = values[i][1:]
+				result[i] = values[i].Pop()
 			}
 
 			mu.Unlock() // unlock before calling destination.Next to prevent long locks
@@ -1570,7 +1550,7 @@ func zipAllInnerSubscriptions[T any](outerCtx context.Context, sources []Observa
 			mu.Lock()
 
 			for i := range sources {
-				if completed[i] && len(values[i]) == 0 {
+				if completed[i] && values[i].Len() == 0 {
 					destination.CompleteWithContext(ctx) // @TODO: Send the last context ?
 					break
 				}

--- a/operator_combining.go
+++ b/operator_combining.go
@@ -1099,7 +1099,7 @@ type zipDestination interface {
 }
 
 // This code is dirty but much more concise than the original implementation.
-func zipInnerSubscription[T any](subscriberCtx context.Context, obs Observable[T], mu *sync.Mutex, values *xqueue.Queue[T], completed *bool, onUpdate func(context.Context), destination zipDestination, subscriptions Subscription) {
+func zipInnerSubscription[T any](subscriberCtx context.Context, obs Observable[T], mu *sync.Mutex, values xqueue.Queue[T], completed *bool, onUpdate func(context.Context), destination zipDestination, subscriptions Subscription) {
 	subscriptions.AddUnsubscribable(
 		obs.SubscribeWithContext(
 			subscriberCtx,
@@ -1162,8 +1162,8 @@ func ZipWith1[A, B any](obsB Observable[B]) func(Observable[A]) Observable[lo.Tu
 		return NewObservableWithContext(func(subscriberCtx context.Context, destination Observer[lo.Tuple2[A, B]]) Teardown {
 			var mu sync.Mutex
 
-			var valueA xqueue.Queue[A]
-			var valueB xqueue.Queue[B]
+			valueA := xqueue.NewQueue[A]()
+			valueB := xqueue.NewQueue[B]()
 
 			var completedA bool
 			var completedB bool
@@ -1191,8 +1191,8 @@ func ZipWith1[A, B any](obsB Observable[B]) func(Observable[A]) Observable[lo.Tu
 			}
 
 			subscriptions := NewSubscription(nil)
-			zipInnerSubscription(subscriberCtx, obsA, &mu, &valueA, &completedA, onUpdate, destination, subscriptions)
-			zipInnerSubscription(subscriberCtx, obsB, &mu, &valueB, &completedB, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsA, &mu, valueA, &completedA, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsB, &mu, valueB, &completedB, onUpdate, destination, subscriptions)
 
 			return func() {
 				subscriptions.Unsubscribe()
@@ -1222,9 +1222,9 @@ func ZipWith2[A, B, C any](obsB Observable[B], obsC Observable[C]) func(Observab
 		return NewObservableWithContext(func(subscriberCtx context.Context, destination Observer[lo.Tuple3[A, B, C]]) Teardown {
 			var mu sync.Mutex
 
-			var valueA xqueue.Queue[A]
-			var valueB xqueue.Queue[B]
-			var valueC xqueue.Queue[C]
+			valueA := xqueue.NewQueue[A]()
+			valueB := xqueue.NewQueue[B]()
+			valueC := xqueue.NewQueue[C]()
 
 			var completedA bool
 			var completedB bool
@@ -1255,9 +1255,9 @@ func ZipWith2[A, B, C any](obsB Observable[B], obsC Observable[C]) func(Observab
 			}
 
 			subscriptions := NewSubscription(nil)
-			zipInnerSubscription(subscriberCtx, obsA, &mu, &valueA, &completedA, onUpdate, destination, subscriptions)
-			zipInnerSubscription(subscriberCtx, obsB, &mu, &valueB, &completedB, onUpdate, destination, subscriptions)
-			zipInnerSubscription(subscriberCtx, obsC, &mu, &valueC, &completedC, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsA, &mu, valueA, &completedA, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsB, &mu, valueB, &completedB, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsC, &mu, valueC, &completedC, onUpdate, destination, subscriptions)
 
 			return func() {
 				subscriptions.Unsubscribe()
@@ -1288,10 +1288,10 @@ func ZipWith3[A, B, C, D any](obsB Observable[B], obsC Observable[C], obsD Obser
 		return NewObservableWithContext(func(subscriberCtx context.Context, destination Observer[lo.Tuple4[A, B, C, D]]) Teardown {
 			var mu sync.Mutex
 
-			var valueA xqueue.Queue[A]
-			var valueB xqueue.Queue[B]
-			var valueC xqueue.Queue[C]
-			var valueD xqueue.Queue[D]
+			valueA := xqueue.NewQueue[A]()
+			valueB := xqueue.NewQueue[B]()
+			valueC := xqueue.NewQueue[C]()
+			valueD := xqueue.NewQueue[D]()
 
 			var completedA bool
 			var completedB bool
@@ -1325,10 +1325,10 @@ func ZipWith3[A, B, C, D any](obsB Observable[B], obsC Observable[C], obsD Obser
 			}
 
 			subscriptions := NewSubscription(nil)
-			zipInnerSubscription(subscriberCtx, obsA, &mu, &valueA, &completedA, onUpdate, destination, subscriptions)
-			zipInnerSubscription(subscriberCtx, obsB, &mu, &valueB, &completedB, onUpdate, destination, subscriptions)
-			zipInnerSubscription(subscriberCtx, obsC, &mu, &valueC, &completedC, onUpdate, destination, subscriptions)
-			zipInnerSubscription(subscriberCtx, obsD, &mu, &valueD, &completedD, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsA, &mu, valueA, &completedA, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsB, &mu, valueB, &completedB, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsC, &mu, valueC, &completedC, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsD, &mu, valueD, &completedD, onUpdate, destination, subscriptions)
 
 			return func() {
 				subscriptions.Unsubscribe()
@@ -1361,11 +1361,11 @@ func ZipWith4[A, B, C, D, E any](obsB Observable[B], obsC Observable[C], obsD Ob
 		return NewObservableWithContext(func(subscriberCtx context.Context, destination Observer[lo.Tuple5[A, B, C, D, E]]) Teardown {
 			var mu sync.Mutex
 
-			var valueA xqueue.Queue[A]
-			var valueB xqueue.Queue[B]
-			var valueC xqueue.Queue[C]
-			var valueD xqueue.Queue[D]
-			var valueE xqueue.Queue[E]
+			valueA := xqueue.NewQueue[A]()
+			valueB := xqueue.NewQueue[B]()
+			valueC := xqueue.NewQueue[C]()
+			valueD := xqueue.NewQueue[D]()
+			valueE := xqueue.NewQueue[E]()
 
 			var completedA bool
 			var completedB bool
@@ -1402,11 +1402,11 @@ func ZipWith4[A, B, C, D, E any](obsB Observable[B], obsC Observable[C], obsD Ob
 			}
 
 			subscriptions := NewSubscription(nil)
-			zipInnerSubscription(subscriberCtx, obsA, &mu, &valueA, &completedA, onUpdate, destination, subscriptions)
-			zipInnerSubscription(subscriberCtx, obsB, &mu, &valueB, &completedB, onUpdate, destination, subscriptions)
-			zipInnerSubscription(subscriberCtx, obsC, &mu, &valueC, &completedC, onUpdate, destination, subscriptions)
-			zipInnerSubscription(subscriberCtx, obsD, &mu, &valueD, &completedD, onUpdate, destination, subscriptions)
-			zipInnerSubscription(subscriberCtx, obsE, &mu, &valueE, &completedE, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsA, &mu, valueA, &completedA, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsB, &mu, valueB, &completedB, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsC, &mu, valueC, &completedC, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsD, &mu, valueD, &completedD, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsE, &mu, valueE, &completedE, onUpdate, destination, subscriptions)
 
 			return func() {
 				subscriptions.Unsubscribe()
@@ -1442,12 +1442,12 @@ func ZipWith5[A, B, C, D, E, F any](obsB Observable[B], obsC Observable[C], obsD
 		return NewObservableWithContext(func(subscriberCtx context.Context, destination Observer[lo.Tuple6[A, B, C, D, E, F]]) Teardown {
 			var mu sync.Mutex
 
-			var valueA xqueue.Queue[A]
-			var valueB xqueue.Queue[B]
-			var valueC xqueue.Queue[C]
-			var valueD xqueue.Queue[D]
-			var valueE xqueue.Queue[E]
-			var valueF xqueue.Queue[F]
+			valueA := xqueue.NewQueue[A]()
+			valueB := xqueue.NewQueue[B]()
+			valueC := xqueue.NewQueue[C]()
+			valueD := xqueue.NewQueue[D]()
+			valueE := xqueue.NewQueue[E]()
+			valueF := xqueue.NewQueue[F]()
 
 			var completedA bool
 			var completedB bool
@@ -1487,12 +1487,12 @@ func ZipWith5[A, B, C, D, E, F any](obsB Observable[B], obsC Observable[C], obsD
 			}
 
 			subscriptions := NewSubscription(nil)
-			zipInnerSubscription(subscriberCtx, obsA, &mu, &valueA, &completedA, onUpdate, destination, subscriptions)
-			zipInnerSubscription(subscriberCtx, obsB, &mu, &valueB, &completedB, onUpdate, destination, subscriptions)
-			zipInnerSubscription(subscriberCtx, obsC, &mu, &valueC, &completedC, onUpdate, destination, subscriptions)
-			zipInnerSubscription(subscriberCtx, obsD, &mu, &valueD, &completedD, onUpdate, destination, subscriptions)
-			zipInnerSubscription(subscriberCtx, obsE, &mu, &valueE, &completedE, onUpdate, destination, subscriptions)
-			zipInnerSubscription(subscriberCtx, obsF, &mu, &valueF, &completedF, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsA, &mu, valueA, &completedA, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsB, &mu, valueB, &completedB, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsC, &mu, valueC, &completedC, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsD, &mu, valueD, &completedD, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsE, &mu, valueE, &completedE, onUpdate, destination, subscriptions)
+			zipInnerSubscription(subscriberCtx, obsF, &mu, valueF, &completedF, onUpdate, destination, subscriptions)
 
 			return func() {
 				subscriptions.Unsubscribe()
@@ -1523,6 +1523,9 @@ func zipAllInnerSubscriptions[T any](outerCtx context.Context, sources []Observa
 	var mu sync.Mutex
 
 	values := make([]xqueue.Queue[T], len(sources))
+	for i := range values {
+		values[i] = xqueue.NewQueue[T]()
+	}
 	completed := make([]bool, len(sources))
 
 	onUpdate := func(ctx context.Context) {
@@ -1564,7 +1567,7 @@ func zipAllInnerSubscriptions[T any](outerCtx context.Context, sources []Observa
 
 	for i := range sources {
 		j := i
-		zipInnerSubscription(outerCtx, sources[i], &mu, &(values[j]), &(completed[j]), onUpdate, destination, subscriptions)
+		zipInnerSubscription(outerCtx, sources[i], &mu, values[j], &(completed[j]), onUpdate, destination, subscriptions)
 	}
 
 	return func() {

--- a/operator_filter.go
+++ b/operator_filter.go
@@ -470,25 +470,31 @@ func TakeLast[T any](count int) func(Observable[T]) Observable[T] {
 
 		return NewUnsafeObservableWithContext(func(subscriberCtx context.Context, destination Observer[T]) Teardown {
 			// Use a circular buffer to avoid memory allocations
-			buffer := make([]lo.Tuple2[context.Context, T], 0, count)
+			buffer := make([]lo.Tuple2[context.Context, T], count)
+			size := 0
 			index := 0
 
 			sub := source.SubscribeWithContext(
 				subscriberCtx,
 				NewObserverWithContext(
 					func(ctx context.Context, value T) {
-						if index >= count {
-							buffer = buffer[1:]
+						buffer[index] = lo.T2(ctx, value)
+						index = (index + 1) % count
+						if size < count {
+							size++
 						}
-
-						buffer = append(buffer, lo.T2(ctx, value))
-						index++
 					},
 					destination.ErrorWithContext,
 					func(ctx context.Context) {
 						// Emit items in order, starting from the oldest
-						for i := 0; i < count && i < index; i++ {
-							destination.NextWithContext(buffer[i].A, buffer[i].B)
+						start := 0
+						if size == count {
+							start = index
+						}
+
+						for i := 0; i < size; i++ {
+							item := buffer[(start+i)%count]
+							destination.NextWithContext(item.A, item.B)
 						}
 
 						destination.CompleteWithContext(ctx)

--- a/subject_replay.go
+++ b/subject_replay.go
@@ -39,6 +39,7 @@ func NewReplaySubject[T any](bufferSize int) Subject[T] {
 
 		err:        lo.Tuple2[context.Context, error]{},
 		values:     []lo.Tuple2[context.Context, T]{},
+		head:       0,
 		bufferSize: bufferSize,
 	}
 }
@@ -50,8 +51,11 @@ type replaySubjectImpl[T any] struct {
 	observers     sync.Map
 	observerIndex uint32
 
-	err        lo.Tuple2[context.Context, error]
+	err lo.Tuple2[context.Context, error]
+	// values is used as a circular buffer when bufferSize > 0: once full, the
+	// oldest value lives at index head and new values overwrite it in place.
 	values     []lo.Tuple2[context.Context, T]
+	head       int
 	bufferSize int
 }
 
@@ -67,8 +71,12 @@ func (s *replaySubjectImpl[T]) SubscribeWithContext(subscriberCtx context.Contex
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	for _, v := range s.values {
-		subscription.NextWithContext(v.A, v.B)
+	// Replay values oldest-first: from head to the end, then the wrapped part.
+	for i := s.head; i < len(s.values); i++ {
+		subscription.NextWithContext(s.values[i].A, s.values[i].B)
+	}
+	for i := 0; i < s.head; i++ {
+		subscription.NextWithContext(s.values[i].A, s.values[i].B)
 	}
 
 	switch s.status {
@@ -111,8 +119,24 @@ func (s *replaySubjectImpl[T]) NextWithContext(ctx context.Context, value T) {
 	if s.status == KindNext {
 		s.broadcastNext(ctx, value)
 
-		s.values = append(s.values, lo.T2(ctx, value))
-		if s.bufferSize != ReplaySubjectUnlimitedBufferSize && len(s.values) > s.bufferSize {
+		switch {
+		case s.bufferSize == ReplaySubjectUnlimitedBufferSize:
+			s.values = append(s.values, lo.T2(ctx, value))
+		case s.bufferSize == 0:
+			// The buffer cannot hold anything: the incoming value is dropped immediately.
+			OnDroppedNotification(ctx, NewNotificationNext(value))
+		case s.bufferSize > 0:
+			if len(s.values) < s.bufferSize {
+				s.values = append(s.values, lo.T2(ctx, value))
+			} else {
+				// Buffer is full: overwrite the oldest value in place.
+				OnDroppedNotification(ctx, NewNotificationNext(s.values[s.head].B))
+				s.values[s.head] = lo.T2(ctx, value)
+				s.head = (s.head + 1) % s.bufferSize
+			}
+		default:
+			// bufferSize < -1 is invalid; kept as-is from the previous implementation.
+			s.values = append(s.values, lo.T2(ctx, value))
 			OnDroppedNotification(ctx, NewNotificationNext(s.values[0].B))
 			s.values = s.values[len(s.values)-s.bufferSize:]
 		}

--- a/subject_replay_test.go
+++ b/subject_replay_test.go
@@ -184,10 +184,19 @@ func TestReplaySubject_internalOverflow(t *testing.T) {
 	subject.Next(84)
 	is.Equal(KindNext, subject.status)
 	is.Empty(subject.err)
-	is.Equal([]int{42, 84}, t2ToSliceB(subject.values))
+	// the circular buffer overwrites the oldest value in place: 84 replaced 21
+	is.Equal([]int{84, 42}, t2ToSliceB(subject.values))
+	is.Equal(1, subject.head)
 	is.Equal(2, subject.bufferSize)
 	is.Equal(0, syncMapLength(&subject.observers))
 	is.Equal(uint32(0), subject.observerIndex)
+
+	// new subscribers replay values oldest-first
+	values := []int{}
+	subject.Subscribe(OnNext(func(value int) {
+		values = append(values, value)
+	})).Unsubscribe()
+	is.Equal([]int{42, 84}, values)
 }
 
 func TestReplaySubject_hasObserver(t *testing.T) {

--- a/subscriber.go
+++ b/subscriber.go
@@ -16,9 +16,8 @@ package ro
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
-
-	"github.com/samber/ro/internal/xsync"
 )
 
 // Subscriber implements the Observer and Subscription interfaces. While the Observer is
@@ -102,11 +101,11 @@ func NewSubscriberWithConcurrencyMode[T any](destination Observer[T], mode Concu
 	// only for short-lived local locks.
 	switch mode {
 	case ConcurrencyModeSafe:
-		return newSubscriberImpl(mode, xsync.NewMutexWithLock(), BackpressureBlock, destination)
+		return newSubscriberImpl(mode, false, BackpressureBlock, destination)
 	case ConcurrencyModeUnsafe:
-		return newSubscriberImpl(mode, xsync.NewMutexWithoutLock(), BackpressureBlock, destination)
+		return newSubscriberImpl(mode, true, BackpressureBlock, destination)
 	case ConcurrencyModeEventuallySafe:
-		return newSubscriberImpl(mode, xsync.NewMutexWithLock(), BackpressureDrop, destination)
+		return newSubscriberImpl(mode, false, BackpressureDrop, destination)
 	default:
 		panic("invalid concurrency mode")
 	}
@@ -114,7 +113,7 @@ func NewSubscriberWithConcurrencyMode[T any](destination Observer[T], mode Concu
 
 // newSubscriberImpl creates a new subscriber implementation with the specified
 // synchronization behavior and destination observer.
-func newSubscriberImpl[T any](mode ConcurrencyMode, mu xsync.Mutex, backpressure Backpressure, destination Observer[T]) Subscriber[T] {
+func newSubscriberImpl[T any](mode ConcurrencyMode, noLock bool, backpressure Backpressure, destination Observer[T]) Subscriber[T] {
 	// Protect against multiple encapsulation layers.
 	if subscriber, ok := destination.(Subscriber[T]); ok {
 		return subscriber
@@ -124,7 +123,7 @@ func newSubscriberImpl[T any](mode ConcurrencyMode, mu xsync.Mutex, backpressure
 		status:       0, // KindNext
 		backpressure: backpressure,
 
-		mu:          mu,
+		noLock:      noLock,
 		destination: destination,
 
 		Subscription: NewSubscription(nil),
@@ -153,18 +152,43 @@ type subscriberImpl[T any] struct {
 
 	// Mutex are much much faster than channels.
 	//
+	// A concrete sync.Mutex (instead of an xsync.Mutex interface) keeps the
+	// lock fast path inlinable: interface dispatch on every Next is measurably
+	// slower. ConcurrencyModeUnsafe skips the lock via the noLock flag.
+	//
 	// Also, generators has been added in go1.23. A different implem of Observable/Observer
 	// might reduce latency induced by mutexes.
 	//
 	// It could be interesting to implement a lock-free version of this,
 	// with message drop instead of backpressure, and when SLO must be kept under
 	// control (real-time streams?).
-	mu          xsync.Mutex
+	mu          sync.Mutex
+	noLock      bool
 	destination Observer[T]
 
 	Subscription
 
 	mode ConcurrencyMode
+}
+
+func (s *subscriberImpl[T]) lock() {
+	if !s.noLock {
+		s.mu.Lock()
+	}
+}
+
+func (s *subscriberImpl[T]) unlock() {
+	if !s.noLock {
+		s.mu.Unlock()
+	}
+}
+
+func (s *subscriberImpl[T]) tryLock() bool {
+	if s.noLock {
+		return true
+	}
+
+	return s.mu.TryLock()
 }
 
 // Implements Observer.
@@ -179,12 +203,12 @@ func (s *subscriberImpl[T]) NextWithContext(ctx context.Context, v T) {
 	}
 
 	if s.backpressure == BackpressureDrop {
-		if !s.mu.TryLock() {
+		if !s.tryLock() {
 			OnDroppedNotification(ctx, NewNotificationNext(v))
 			return
 		}
 	} else {
-		s.mu.Lock()
+		s.lock()
 	}
 
 	if atomic.LoadInt32(&s.status) == 0 {
@@ -193,7 +217,7 @@ func (s *subscriberImpl[T]) NextWithContext(ctx context.Context, v T) {
 		OnDroppedNotification(ctx, NewNotificationNext(v))
 	}
 
-	s.mu.Unlock()
+	s.unlock()
 }
 
 // Implements Observer.
@@ -203,7 +227,7 @@ func (s *subscriberImpl[T]) Error(err error) {
 
 // Implements Observer.
 func (s *subscriberImpl[T]) ErrorWithContext(ctx context.Context, err error) {
-	s.mu.Lock()
+	s.lock()
 
 	if atomic.CompareAndSwapInt32(&s.status, 0, 1) {
 		if s.destination != nil {
@@ -213,7 +237,7 @@ func (s *subscriberImpl[T]) ErrorWithContext(ctx context.Context, err error) {
 		OnDroppedNotification(ctx, NewNotificationError[T](err))
 	}
 
-	s.mu.Unlock()
+	s.unlock()
 
 	s.unsubscribe()
 }
@@ -225,7 +249,7 @@ func (s *subscriberImpl[T]) Complete() {
 
 // Implements Observer.
 func (s *subscriberImpl[T]) CompleteWithContext(ctx context.Context) {
-	s.mu.Lock()
+	s.lock()
 
 	if atomic.CompareAndSwapInt32(&s.status, 0, 2) {
 		if s.destination != nil {
@@ -235,7 +259,7 @@ func (s *subscriberImpl[T]) CompleteWithContext(ctx context.Context) {
 		OnDroppedNotification(ctx, NewNotificationComplete[T]())
 	}
 
-	s.mu.Unlock()
+	s.unlock()
 
 	s.unsubscribe()
 }

--- a/subscriber.go
+++ b/subscriber.go
@@ -150,7 +150,7 @@ type subscriberImpl[T any] struct {
 
 	_ [59]byte // padding to prevent false sharing
 
-	// Mutex are much much faster than channels.
+	// Mutexes are much faster than channels.
 	//
 	// A concrete sync.Mutex (instead of an xsync.Mutex interface) keeps the
 	// lock fast path inlinable: interface dispatch on every Next is measurably


### PR DESCRIPTION
## Summary

Performance pass over the core package, driven by benchmarks: establish a baseline first, apply one optimization per commit, and validate each with `benchstat -count=10 -benchmem`. **No public API or behavior changes** — only internal data structures.

A new benchmark suite lives in `bench/` and covers the per-event hot paths (Observer/Subscriber `Next`, pipe chains, subject fanout) and the buffering operators.

## Optimizations

1. **`TakeLast`: real circular buffer** — the previous code did `buffer = buffer[1:]` + `append`, which reallocates and copies the whole window on every item once full. Now uses the same ring-buffer pattern as `SkipLast`.
2. **Zip family: pointer-free reusable FIFO queue** (`internal/xqueue`) — pending values were queued as `[]*T` with `&v` (one heap escape per event) and popped by reslicing, forcing a fresh slice allocation on almost every push in the balanced steady state. The new queue stores values, zeroes popped slots (no pinning), and reuses its backing array. Covers `Zip`, `Zip2..6`, `ZipWith1..5`, `ZipAll` via `zipInnerSubscription`.
3. **Bounded `ReplaySubject`: circular buffer** — same append-and-trim realloc churn removed; per-overflow drop notifications and oldest-first replay order preserved exactly.
4. **Subscriber: concrete `sync.Mutex` instead of the `xsync.Mutex` interface** — removes non-inlinable interface dispatch on every Next/Error/Complete and one heap object per subscriber. `ConcurrencyModeUnsafe` skips the lock via an inlined `noLock` branch.

## Results

benchstat, n=10, goos: linux / goarch: amd64 / cpu: Intel(R) Xeon(R) Processor @ 2.80GHz:

| benchmark | time | B/op | allocs/op |
|---|---|---|---|
| `TakeLast(8)` over 1024 items | **−37.8%** | **−97.6%** | 173 → 27 |
| `TakeLast(128)` | −15.0% | −87.4% | 38 → 31 |
| `Zip2` / `ZipWith1` (256 pairs) | **−21.9%** / −20.8% | −31.7% | 825 → 58 (**−93%**) |
| `ReplaySubject(16)` Next, steady state | −5.5% | −56.8% | — |
| `SubscriberNext` unsafe / eventually-safe | −4.9% / −6.8% | — | — |
| `Collect` over 1000-item Map+Filter pipe | −3.2% | — | — |

All improvements are statistically significant (p ≤ 0.02); full per-commit benchstat tables are in the commit messages.

## Hypotheses rejected by measurement

- The `lo.TryCatchWithErrorValue` closures in `observer.go` looked like 2 heap escapes per event, but on go1.24 the compiler inlines the whole call chain: bare `Next` is already ~17 ns / 0 allocs. Left untouched.
- The subjects' broadcast path (`sync.Map.Range` + per-observer type assertion) was considered but **deferred**: the teardown `Delete` legally runs lock-free mid-broadcast, so a copy-on-write snapshot refactor across all five subject implementations carries real deadlock/race risk for ~1 alloc per broadcast of payoff. The fanout benchmarks are in the tree as a baseline for that future work.

## Behavior notes

- `TestReplaySubject_internalOverflow` asserted the raw internal slice order, which changes with in-place ring overwrites; it now asserts the ring layout and additionally verifies the replayed (logical) order.
- The invalid `ReplaySubject(bufferSize < -1)` branch is kept bit-for-bit (it panicked on first `Next` before and still does).
- `make test` (race + goleak) green across the workspace, except the pre-existing environmental failure `plugins/proc/TestNewHostUserWatcher` (no `/var/run/utmp` in the container — fails identically on `main`).

https://claude.ai/code/session_016w2Cp12a5dfEut7VrNr75D

---
_Generated by [Claude Code](https://claude.ai/code/session_016w2Cp12a5dfEut7VrNr75D)_