### PR TITLE
perf: reuse cases.Title caser via sync.Pool in Capitalize

### DIFF
--- a/internal/xqueue/queue_test.go
+++ b/internal/xqueue/queue_test.go
@@ -43,7 +43,7 @@ func TestQueuePushPop(t *testing.T) {
 	is.Equal(0, q.Len())
 }
 
-func TestQueueReusesCapacityWhenDrained(t *testing.T) {
+func TestQueueReusesCapacityWhenDrained(t *testing.T) { //nolint:paralleltest
 	// Not parallel: testing.AllocsPerRun is unreliable when other tests run
 	// concurrently, since its result depends on whole-program GC behavior.
 	is := assert.New(t)
@@ -178,5 +178,5 @@ func TestQueueInterleaved(t *testing.T) {
 		expected++
 	}
 
-	is.Equal(next, expected)
+	is.Equal(expected, next)
 }

--- a/plugins/bytes/operator_capitalize.go
+++ b/plugins/bytes/operator_capitalize.go
@@ -15,13 +15,27 @@
 package robytes
 
 import (
+	"sync"
+
 	"github.com/samber/ro"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
 
+// titleCaserPool reuses cases.Title casers: constructing one is far more
+// expensive than the casing itself, and a Caser is not safe for concurrent
+// use, so it cannot be a plain package-level singleton.
+var titleCaserPool = sync.Pool{
+	New: func() any {
+		c := cases.Title(language.English)
+		return &c
+	},
+}
+
 func capitalize(str []byte) []byte {
-	return cases.Title(language.English).Bytes(str)
+	c, _ := titleCaserPool.Get().(*cases.Caser) // Pool.New always returns *cases.Caser, so the assertion never fails.
+	defer titleCaserPool.Put(c)
+	return c.Bytes(str)
 }
 
 // Capitalize capitalizes the first letter of the string.

--- a/plugins/strings/operator_capitalize.go
+++ b/plugins/strings/operator_capitalize.go
@@ -15,13 +15,27 @@
 package rostrings
 
 import (
+	"sync"
+
 	"github.com/samber/ro"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
 
+// titleCaserPool reuses cases.Title casers: constructing one is far more
+// expensive than the casing itself, and a Caser is not safe for concurrent
+// use, so it cannot be a plain package-level singleton.
+var titleCaserPool = sync.Pool{
+	New: func() any {
+		c := cases.Title(language.English)
+		return &c
+	},
+}
+
 func capitalize(str string) string {
-	return cases.Title(language.English).String(str)
+	c, _ := titleCaserPool.Get().(*cases.Caser) // Pool.New always returns *cases.Caser, so the assertion never fails.
+	defer titleCaserPool.Put(c)
+	return c.String(str)
 }
 
 // Capitalize capitalizes the first letter of the string.


### PR DESCRIPTION
## Summary

\`Capitalize\` was calling \`cases.Title(language.English)\` on every invocation, which constructs a new \`Caser\` transformer each time. Building the transformer costs more than the actual casing operation.

A \`Caser\` is not safe for concurrent use, so a plain \`var\` singleton is not an option — \`sync.Pool\` is the right fit: it reuses objects across calls while keeping each goroutine working on its own instance.

Applies to both \`plugins/strings\` and \`plugins/bytes\`. \`CamelCase\` and \`PascalCase\` also benefit since they call \`capitalize()\` internally.

Inspired by [samber/lo#915](https://github.com/samber/lo/pull/915).

## Benchstat

```
goos: darwin
goarch: arm64
pkg: github.com/samber/ro/plugins/strings
cpu: Apple M3

             │    before    │              after              │
             │   sec/op     │   sec/op      vs base          │
Capitalize-8   231.9n ± 5%   152.9n ± 10%  -34.04% (p=0.002 n=6)

             │    before    │             after              │
             │    B/op      │    B/op     vs base            │
Capitalize-8   448.0 ± 0%   272.0 ± 0%   -39.29% (p=0.002 n=6)

             │    before    │             after              │
             │  allocs/op   │ allocs/op   vs base            │
Capitalize-8   4.000 ± 0%   2.000 ± 0%   -50.00% (p=0.002 n=6)
```

- **-34%** temps (232 → 153 ns/op)
- **-39%** mémoire (448 → 272 B/op)
- **-50%** allocations (4 → 2 allocs/op)