### PR TITLE
docs: add missing operator documentation (28 new files)

### DIFF
--- a/docs/data/core-cast.md
+++ b/docs/data/core-cast.md
@@ -1,0 +1,32 @@
+---
+name: Cast
+slug: cast
+sourceRef: operator_transformations.go#L236
+type: core
+category: transformation
+signatures:
+  - "func Cast[T any, U any]()"
+playUrl: ""
+variantHelpers:
+  - core#transformation#cast
+similarHelpers:
+  - core#transformation#map
+position: 110
+---
+
+Casts each item emitted by an Observable to a target type. Panics if the item cannot be cast to the target type.
+
+```go
+obs := ro.Pipe[any, int](
+    ro.Just[any](1, 2, 3),
+    ro.Cast[any, int](),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[int]())
+defer sub.Unsubscribe()
+
+// Next: 1
+// Next: 2
+// Next: 3
+// Completed
+```

--- a/docs/data/core-collect.md
+++ b/docs/data/core-collect.md
@@ -1,0 +1,39 @@
+---
+name: Collect
+slug: collect
+sourceRef: observable.go#L327
+type: core
+category: sink
+signatures:
+  - "func Collect[T any](obs Observable[T]) ([]T, error)"
+  - "func CollectWithContext[T any](ctx context.Context, obs Observable[T]) ([]T, context.Context, error)"
+playUrl: ""
+variantHelpers:
+  - core#sink#collect
+  - core#sink#collectwithcontext
+similarHelpers:
+  - core#sink#toslice
+  - core#sink#tomap
+position: 0
+---
+
+Subscribes to an Observable and collects all emitted values into a slice, blocking until the Observable completes or errors.
+
+This is a blocking sink function — unlike ToSlice, it does not return an Observable and is typically used in tests or when all values need to be gathered before proceeding.
+
+```go
+values, err := ro.Collect(ro.Just(1, 2, 3, 4, 5))
+
+fmt.Println(values) // [1 2 3 4 5]
+fmt.Println(err)    // <nil>
+```
+
+### With context
+
+```go
+ctx := context.Background()
+values, ctx, err := ro.CollectWithContext(ctx, ro.Just("a", "b", "c"))
+
+fmt.Println(values) // [a b c]
+fmt.Println(err)    // <nil>
+```

--- a/docs/data/core-contextwithdeadline.md
+++ b/docs/data/core-contextwithdeadline.md
@@ -6,11 +6,9 @@ type: core
 category: context
 signatures:
   - "func ContextWithDeadline[T any](deadline time.Time)"
-  - "func ContextWithDeadlineCause[T any](deadline time.Time, cause error)"
 playUrl: https://go.dev/play/p/NPYFzhI2YDK
 variantHelpers:
   - core#context#contextwithdeadline
-  - core#context#contextwithdeadlinecause
 similarHelpers:
   - core#context#contextwithtimeout
   - core#context#throwoncontextcancel
@@ -56,27 +54,6 @@ defer sub.Unsubscribe()
 
 // Next: "Success: fast_operation"
 // Completed
-```
-
-### With ContextWithDeadlineCause
-
-```go
-deadline := time.Now().Add(50 * time.Millisecond)
-deadlineError := errors.New("processing deadline exceeded")
-obs := ro.Pipe[string, string](
-    ro.Just("data_processing"),
-    ro.ContextWithDeadlineCause[string](deadline, deadlineError),
-    ro.ThrowOnContextCancel[string](),
-    ro.Map(func(s string) string {
-        time.Sleep(100 * time.Millisecond) // Will exceed deadline
-        return fmt.Sprintf("Result: %s", s)
-    }),
-)
-
-sub := obs.Subscribe(ro.PrintObserver[string]())
-defer sub.Unsubscribe()
-
-// Error: processing deadline exceeded (custom cause error)
 ```
 
 ### With future deadline

--- a/docs/data/core-contextwithtimeout.md
+++ b/docs/data/core-contextwithtimeout.md
@@ -6,11 +6,9 @@ type: core
 category: context
 signatures:
   - "func ContextWithTimeout[T any](timeout time.Duration)"
-  - "func ContextWithTimeoutCause[T any](timeout time.Duration, cause error)"
 playUrl: https://go.dev/play/p/1qijKGsyn0D
 variantHelpers:
   - core#context#contextwithtimeout
-  - core#context#contextwithtimeoutcause
 similarHelpers:
   - core#context#contextwithdeadline
   - core#context#throwoncontextcancel
@@ -54,26 +52,6 @@ defer sub.Unsubscribe()
 
 // Next: "Success: fast_operation"
 // Completed
-```
-
-### With ContextWithTimeoutCause
-
-```go
-timeoutError := errors.New("operation timed out")
-obs := ro.Pipe[string, string](
-    ro.Just("data_processing"),
-    ro.ContextWithTimeoutCause[string](50 * time.Millisecond, timeoutError),
-    ro.ThrowOnContextCancel[string](),
-    ro.Map(func(s string) string {
-        time.Sleep(100 * time.Millisecond) // Will timeout
-        return fmt.Sprintf("Result: %s", s)
-    }),
-)
-
-sub := obs.Subscribe(ro.PrintObserver[string]())
-defer sub.Unsubscribe()
-
-// Error: operation timed out (custom cause error)
 ```
 
 ### With multiple operations and timeout

--- a/docs/data/core-delayeach.md
+++ b/docs/data/core-delayeach.md
@@ -1,0 +1,38 @@
+---
+name: DelayEach
+slug: delayeach
+sourceRef: operator_utility.go#L371
+type: core
+category: utility
+signatures:
+  - "func DelayEach[T any](duration time.Duration)"
+playUrl: ""
+variantHelpers:
+  - core#utility#delayeach
+similarHelpers:
+  - core#utility#delay
+  - core#utility#timeout
+position: 221
+---
+
+Delays each item emitted by the source Observable by a fixed duration before forwarding it.
+
+Unlike Delay which shifts all emissions by the same amount, DelayEach introduces a per-item pause.
+
+```go
+obs := ro.Pipe[string, string](
+    ro.Just("A", "B", "C"),
+    ro.DelayEach[string](100 * time.Millisecond),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[string]())
+defer sub.Unsubscribe()
+
+// (100ms pause)
+// Next: A
+// (100ms pause)
+// Next: B
+// (100ms pause)
+// Next: C
+// Completed
+```

--- a/docs/data/core-endwith.md
+++ b/docs/data/core-endwith.md
@@ -1,0 +1,34 @@
+---
+name: EndWith
+slug: endwith
+sourceRef: operator_combining.go#L949
+type: core
+category: combining
+signatures:
+  - "func EndWith[T any](suffixes ...T)"
+playUrl: ""
+variantHelpers:
+  - core#combining#endwith
+similarHelpers:
+  - core#combining#startwith
+position: 76
+---
+
+Emits additional values after the source Observable completes.
+
+```go
+obs := ro.Pipe[int, int](
+    ro.Just(1, 2, 3),
+    ro.EndWith(4, 5),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[int]())
+defer sub.Unsubscribe()
+
+// Next: 1
+// Next: 2
+// Next: 3
+// Next: 4
+// Next: 5
+// Completed
+```

--- a/docs/data/core-flatmap.md
+++ b/docs/data/core-flatmap.md
@@ -17,6 +17,7 @@ variantHelpers:
   - core#transformation#flatmapiwithcontext
 similarHelpers:
   - core#transformation#map
+  - core#transformation#flatten
   - core#combining#mergemap
 position: 10
 ---

--- a/docs/data/core-flatten.md
+++ b/docs/data/core-flatten.md
@@ -1,0 +1,36 @@
+---
+name: Flatten
+slug: flatten
+sourceRef: operator_transformations.go#L213
+type: core
+category: transformation
+signatures:
+  - "func Flatten[T any]()"
+playUrl: ""
+variantHelpers:
+  - core#transformation#flatten
+similarHelpers:
+  - core#transformation#flatmap
+  - core#transformation#mergeall
+position: 11
+---
+
+Flattens an Observable of slices into an Observable of individual items.
+
+```go
+obs := ro.Pipe[[]int, int](
+    ro.Just([]int{1, 2, 3}, []int{4, 5, 6}),
+    ro.Flatten[int](),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[int]())
+defer sub.Unsubscribe()
+
+// Next: 1
+// Next: 2
+// Next: 3
+// Next: 4
+// Next: 5
+// Next: 6
+// Completed
+```

--- a/docs/data/core-map.md
+++ b/docs/data/core-map.md
@@ -16,8 +16,8 @@ variantHelpers:
   - core#transformation#mapi
   - core#transformation#mapiwithcontext
 similarHelpers:
-  - core#transformation#mapto,
-  - core#transformation#maperr,
+  - core#transformation#mapto
+  - core#transformation#maperr
   - core#transformation#flatmap
 position: 0
 ---

--- a/docs/data/core-mapto.md
+++ b/docs/data/core-mapto.md
@@ -1,0 +1,35 @@
+---
+name: MapTo
+slug: mapto
+sourceRef: operator_transformations.go#L80
+type: core
+category: transformation
+signatures:
+  - "func MapTo[T any, R any](output R)"
+playUrl: ""
+variantHelpers:
+  - core#transformation#mapto
+similarHelpers:
+  - core#transformation#map
+  - core#transformation#maperr
+position: 1
+---
+
+Maps every item emitted by an Observable to the same constant value.
+
+```go
+obs := ro.Pipe[int, string](
+    ro.Just(1, 2, 3, 4, 5),
+    ro.MapTo[int, string]("hello"),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[string]())
+defer sub.Unsubscribe()
+
+// Next: hello
+// Next: hello
+// Next: hello
+// Next: hello
+// Next: hello
+// Completed
+```

--- a/docs/data/core-repeat.md
+++ b/docs/data/core-repeat.md
@@ -10,6 +10,7 @@ playUrl: https://go.dev/play/p/CUvh_TYALNe
 variantHelpers:
   - core#creation#repeat
 similarHelpers:
+  - core#creation#repeatwith
   - core#creation#repeatwithinterval
 position: 37
 ---

--- a/docs/data/core-repeatwith.md
+++ b/docs/data/core-repeatwith.md
@@ -1,0 +1,39 @@
+---
+name: RepeatWith
+slug: repeatwith
+sourceRef: operator_utility.go#L396
+type: core
+category: utility
+signatures:
+  - "func RepeatWith[T any](count int64)"
+playUrl: ""
+variantHelpers:
+  - core#utility#repeatwith
+similarHelpers:
+  - core#creation#repeat
+  - core#creation#repeatwithinterval
+position: 400
+---
+
+Repeats the source Observable a fixed number of times by re-subscribing after each completion.
+
+```go
+obs := ro.Pipe[int, int](
+    ro.Just(1, 2, 3),
+    ro.RepeatWith[int](3),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[int]())
+defer sub.Unsubscribe()
+
+// Next: 1
+// Next: 2
+// Next: 3
+// Next: 1
+// Next: 2
+// Next: 3
+// Next: 1
+// Next: 2
+// Next: 3
+// Completed
+```

--- a/docs/data/core-sampletime.md
+++ b/docs/data/core-sampletime.md
@@ -1,0 +1,32 @@
+---
+name: SampleTime
+slug: sampletime
+sourceRef: operator_transformations.go#L771
+type: core
+category: transformation
+signatures:
+  - "func SampleTime[T any](interval time.Duration)"
+playUrl: ""
+variantHelpers:
+  - core#transformation#sampletime
+similarHelpers:
+  - core#transformation#samplewhen
+  - core#transformation#throttletime
+  - core#transformation#throttlewhen
+position: 91
+---
+
+Emits the most recently emitted item from the source Observable at regular time intervals.
+
+```go
+obs := ro.Pipe[int, int](
+    ro.Interval(30 * time.Millisecond),
+    ro.SampleTime[int](100 * time.Millisecond),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[int]())
+time.Sleep(350 * time.Millisecond)
+sub.Unsubscribe()
+
+// Emits the latest value every 100ms
+```

--- a/docs/data/core-samplewhen.md
+++ b/docs/data/core-samplewhen.md
@@ -1,0 +1,34 @@
+---
+name: SampleWhen
+slug: samplewhen
+sourceRef: operator_transformations.go#L707
+type: core
+category: transformation
+signatures:
+  - "func SampleWhen[T any, t any](tick Observable[t])"
+playUrl: ""
+variantHelpers:
+  - core#transformation#samplewhen
+similarHelpers:
+  - core#transformation#sampletime
+  - core#transformation#throttlewhen
+  - core#transformation#throttletime
+position: 90
+---
+
+Emits the most recently emitted item from the source Observable whenever a tick Observable emits.
+
+```go
+tick := ro.Interval(100 * time.Millisecond)
+
+obs := ro.Pipe[int, int](
+    ro.Interval(30 * time.Millisecond),
+    ro.SampleWhen[int](tick),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[int]())
+time.Sleep(350 * time.Millisecond)
+sub.Unsubscribe()
+
+// Emits the latest value every ~100ms
+```

--- a/docs/data/core-skip.md
+++ b/docs/data/core-skip.md
@@ -9,7 +9,10 @@ signatures:
 playUrl: https://go.dev/play/p/AAEJaUZJuIj
 variantHelpers:
   - core#filtering#skip
-similarHelpers: []
+similarHelpers:
+  - core#filtering#skiplast
+  - core#filtering#skipuntil
+  - core#filtering#skipwhile
 position: 80
 ---
 

--- a/docs/data/core-skiplast.md
+++ b/docs/data/core-skiplast.md
@@ -1,0 +1,33 @@
+---
+name: SkipLast
+slug: skiplast
+sourceRef: operator_filter.go#L262
+type: core
+category: filtering
+signatures:
+  - "func SkipLast[T any](count int)"
+playUrl: ""
+variantHelpers:
+  - core#filtering#skiplast
+similarHelpers:
+  - core#filtering#skip
+  - core#filtering#takelast
+position: 262
+---
+
+Suppresses the last n items emitted by an Observable.
+
+```go
+obs := ro.Pipe[int, int](
+    ro.Just(1, 2, 3, 4, 5),
+    ro.SkipLast[int](2),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[int]())
+defer sub.Unsubscribe()
+
+// Next: 1
+// Next: 2
+// Next: 3
+// Completed
+```

--- a/docs/data/core-skipuntil.md
+++ b/docs/data/core-skipuntil.md
@@ -1,0 +1,38 @@
+---
+name: SkipUntil
+slug: skipuntil
+sourceRef: operator_filter.go#L302
+type: core
+category: filtering
+signatures:
+  - "func SkipUntil[T any, S any](signal Observable[S])"
+playUrl: ""
+variantHelpers:
+  - core#filtering#skipuntil
+similarHelpers:
+  - core#filtering#skip
+  - core#filtering#skipwhile
+  - core#filtering#takeuntil
+position: 92
+---
+
+Skips items emitted by the source Observable until a signal Observable emits.
+
+```go
+signal := ro.Timer(200 * time.Millisecond)
+
+obs := ro.Pipe[int, int](
+    ro.Interval(50 * time.Millisecond),
+    ro.SkipUntil[int](signal),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[int]())
+time.Sleep(400 * time.Millisecond)
+sub.Unsubscribe()
+
+// (items emitted before 200ms are skipped)
+// Next: 4
+// Next: 5
+// Next: 6
+// ...
+```

--- a/docs/data/core-takeuntil.md
+++ b/docs/data/core-takeuntil.md
@@ -1,0 +1,37 @@
+---
+name: TakeUntil
+slug: takeuntil
+sourceRef: operator_filter.go#L516
+type: core
+category: filtering
+signatures:
+  - "func TakeUntil[T any, S any](signal Observable[S])"
+playUrl: ""
+variantHelpers:
+  - core#filtering#takeuntil
+similarHelpers:
+  - core#filtering#take
+  - core#filtering#takewhile
+  - core#filtering#skipuntil
+position: 21
+---
+
+Emits items from the source Observable until a signal Observable emits or completes.
+
+```go
+signal := ro.Timer(200 * time.Millisecond)
+
+obs := ro.Pipe[int, int](
+    ro.Interval(50 * time.Millisecond),
+    ro.TakeUntil[int](signal),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[int]())
+defer sub.Unsubscribe()
+
+// Next: 0
+// Next: 1
+// Next: 2
+// Next: 3
+// Completed (after ~200ms)
+```

--- a/docs/data/core-throttletime.md
+++ b/docs/data/core-throttletime.md
@@ -1,0 +1,32 @@
+---
+name: ThrottleTime
+slug: throttletime
+sourceRef: operator_transformations.go#L829
+type: core
+category: transformation
+signatures:
+  - "func ThrottleTime[T any](interval time.Duration)"
+playUrl: ""
+variantHelpers:
+  - core#transformation#throttletime
+similarHelpers:
+  - core#transformation#throttlewhen
+  - core#transformation#sampletime
+  - core#transformation#samplewhen
+position: 93
+---
+
+Emits a value from the source Observable, then ignores subsequent source values for a fixed time duration.
+
+```go
+obs := ro.Pipe[int, int](
+    ro.Interval(20 * time.Millisecond),
+    ro.ThrottleTime[int](100 * time.Millisecond),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[int]())
+time.Sleep(350 * time.Millisecond)
+sub.Unsubscribe()
+
+// Emits first item, then ignores items for 100ms
+```

--- a/docs/data/core-throttlewhen.md
+++ b/docs/data/core-throttlewhen.md
@@ -1,0 +1,34 @@
+---
+name: ThrottleWhen
+slug: throttlewhen
+sourceRef: operator_transformations.go#L780
+type: core
+category: transformation
+signatures:
+  - "func ThrottleWhen[T any, t any](tick Observable[t])"
+playUrl: ""
+variantHelpers:
+  - core#transformation#throttlewhen
+similarHelpers:
+  - core#transformation#throttletime
+  - core#transformation#samplewhen
+  - core#transformation#sampletime
+position: 92
+---
+
+Emits a value from the source Observable, then ignores subsequent source values for a duration determined by the tick Observable.
+
+```go
+tick := ro.Interval(100 * time.Millisecond)
+
+obs := ro.Pipe[int, int](
+    ro.Interval(20 * time.Millisecond),
+    ro.ThrottleWhen[int](tick),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[int]())
+time.Sleep(350 * time.Millisecond)
+sub.Unsubscribe()
+
+// Emits first item, then throttles until next tick
+```

--- a/docs/data/core-tochannel.md
+++ b/docs/data/core-tochannel.md
@@ -10,7 +10,6 @@ signatures:
 playUrl: https://go.dev/play/p/WMKa26sirV0
 variantHelpers:
   - core#sink#tochannel
-  - core#sink#tochannelwithcontext
 similarHelpers:
   - core#sink#toslice
   - core#sink#tomap

--- a/docs/data/core-trunc.md
+++ b/docs/data/core-trunc.md
@@ -1,0 +1,35 @@
+---
+name: Trunc
+slug: trunc
+sourceRef: operator_math.go#L796
+type: core
+category: math
+signatures:
+  - "func Trunc()"
+playUrl: ""
+variantHelpers:
+  - core#math#trunc
+similarHelpers:
+  - core#math#round
+  - core#math#floor
+  - core#math#ceil
+position: 31
+---
+
+Returns the integer value of each float64 emitted by the source Observable, truncating toward zero.
+
+```go
+obs := ro.Pipe[float64, float64](
+    ro.Just(1.7, -1.7, 2.3, -2.3),
+    ro.Trunc(),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[float64]())
+defer sub.Unsubscribe()
+
+// Next: 1
+// Next: -1
+// Next: 2
+// Next: -2
+// Completed
+```

--- a/docs/data/plugin-observability-slog-logwithnotification.md
+++ b/docs/data/plugin-observability-slog-logwithnotification.md
@@ -1,0 +1,44 @@
+---
+name: LogWithNotification
+slug: logwithnotification
+sourceRef: plugins/observability/slog/operator.go#L40
+type: plugin
+category: logger-slog
+signatures:
+  - "func LogWithNotification[T any](logger slog.Logger, level slog.Level)"
+playUrl: ""
+variantHelpers:
+  - plugin#logger-slog#logwithnotification
+similarHelpers:
+  - plugin#logger-slog#log
+position: 10
+---
+
+Logs each notification (Next, Error, Complete) emitted by the source Observable using structured logging with slog.
+
+```go
+import (
+    "log/slog"
+    "os"
+
+    "github.com/samber/ro"
+    roslog "github.com/samber/ro/plugins/observability/slog"
+)
+
+logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+obs := ro.Pipe[string, string](
+    ro.Just("operation 1", "operation 2"),
+    roslog.LogWithNotification[string](logger, slog.LevelInfo),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[string]())
+defer sub.Unsubscribe()
+
+// Logs: time=... level=INFO msg=next value="operation 1"
+// Logs: time=... level=INFO msg=next value="operation 2"
+// Logs: time=... level=INFO msg=complete
+// Next: operation 1
+// Next: operation 2
+// Completed
+```

--- a/docs/data/plugin-ozzo-validation-validateorerror.md
+++ b/docs/data/plugin-ozzo-validation-validateorerror.md
@@ -11,6 +11,7 @@ variantHelpers:
   - plugin#ozzo-validation#validateorerror
 similarHelpers:
   - plugin#ozzo-validation#validate
+  - plugin#ozzo-validation#validateorerrorwithcontext
 position: 80
 ---
 

--- a/docs/data/plugin-ozzo-validation-validateorerrorwithcontext.md
+++ b/docs/data/plugin-ozzo-validation-validateorerrorwithcontext.md
@@ -1,0 +1,38 @@
+---
+name: ValidateOrErrorWithContext
+slug: validateorerrorwithcontext
+sourceRef: plugins/ozzo/ozzo-validation/operator.go#L101
+type: plugin
+category: ozzo-validation
+signatures:
+  - "func ValidateOrErrorWithContext[T any](rules ...ozzo.Rule)"
+playUrl: ""
+variantHelpers:
+  - plugin#ozzo-validation#validateorerrorwithcontext
+similarHelpers:
+  - plugin#ozzo-validation#validateorerror
+  - plugin#ozzo-validation#validateorskipwithcontext
+position: 82
+---
+
+Validates each item using context-aware ozzo-validation rules. Items that fail validation cause the stream to error; valid items are forwarded unchanged.
+
+```go
+import (
+    validation "github.com/go-ozzo/ozzo-validation/v4"
+    "github.com/samber/ro"
+    roozzo "github.com/samber/ro/plugins/ozzo/ozzo-validation"
+)
+
+obs := ro.Pipe[int, int](
+    ro.Just(5, 15, 25),
+    roozzo.ValidateOrErrorWithContext[int](
+        validation.Min(10),
+    ),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[int]())
+defer sub.Unsubscribe()
+
+// Error: 5 must be no less than 10.
+```

--- a/docs/data/plugin-ozzo-validation-validatestructorerror.md
+++ b/docs/data/plugin-ozzo-validation-validatestructorerror.md
@@ -1,0 +1,53 @@
+---
+name: ValidateStructOrError
+slug: validatestructorerror
+sourceRef: plugins/ozzo/ozzo-validation/operator.go#L89
+type: plugin
+category: ozzo-validation
+signatures:
+  - "func ValidateStructOrError[T any]()"
+playUrl: ""
+variantHelpers:
+  - plugin#ozzo-validation#validatestructorerror
+similarHelpers:
+  - plugin#ozzo-validation#validatestruct
+  - plugin#ozzo-validation#validatestructorskip
+  - plugin#ozzo-validation#validateorerror
+position: 91
+---
+
+Validates each struct item using ozzo-validation. Items that fail validation cause the stream to error; valid items are forwarded unchanged. The struct must implement `validation.Validatable`.
+
+```go
+import (
+    validation "github.com/go-ozzo/ozzo-validation/v4"
+    "github.com/samber/ro"
+    roozzo "github.com/samber/ro/plugins/ozzo/ozzo-validation"
+)
+
+type User struct {
+    Name  string
+    Email string
+}
+
+func (u User) Validate() error {
+    return validation.ValidateStruct(&u,
+        validation.Field(&u.Name, validation.Required),
+        validation.Field(&u.Email, validation.Required),
+    )
+}
+
+obs := ro.Pipe[User, User](
+    ro.Just(
+        User{Name: "Alice", Email: "alice@example.com"},
+        User{Name: "", Email: ""},
+    ),
+    roozzo.ValidateStructOrError[User](),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[User]())
+defer sub.Unsubscribe()
+
+// Next: {Alice alice@example.com}
+// Error: email: cannot be blank; name: cannot be blank.
+```

--- a/docs/data/plugin-ozzo-validation-validatestructorerrorwithcontext.md
+++ b/docs/data/plugin-ozzo-validation-validatestructorerrorwithcontext.md
@@ -1,0 +1,55 @@
+---
+name: ValidateStructOrErrorWithContext
+slug: validatestructorerrorwithcontext
+sourceRef: plugins/ozzo/ozzo-validation/operator.go#L108
+type: plugin
+category: ozzo-validation
+signatures:
+  - "func ValidateStructOrErrorWithContext[T any]()"
+playUrl: ""
+variantHelpers:
+  - plugin#ozzo-validation#validatestructorerrorwithcontext
+similarHelpers:
+  - plugin#ozzo-validation#validatestructorerror
+  - plugin#ozzo-validation#validatestructorskipwithcontext
+  - plugin#ozzo-validation#validateorerrorwithcontext
+position: 92
+---
+
+Validates each struct item using context-aware ozzo-validation. Items that fail validation cause the stream to error; valid items are forwarded unchanged. The struct must implement `validation.ValidatableWithContext`.
+
+```go
+import (
+    "context"
+
+    validation "github.com/go-ozzo/ozzo-validation/v4"
+    "github.com/samber/ro"
+    roozzo "github.com/samber/ro/plugins/ozzo/ozzo-validation"
+)
+
+type User struct {
+    Name  string
+    Email string
+}
+
+func (u User) ValidateWithContext(ctx context.Context) error {
+    return validation.ValidateStructWithContext(ctx, &u,
+        validation.Field(&u.Name, validation.Required),
+        validation.Field(&u.Email, validation.Required),
+    )
+}
+
+obs := ro.Pipe[User, User](
+    ro.Just(
+        User{Name: "Alice", Email: "alice@example.com"},
+        User{Name: "", Email: ""},
+    ),
+    roozzo.ValidateStructOrErrorWithContext[User](),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[User]())
+defer sub.Unsubscribe()
+
+// Next: {Alice alice@example.com}
+// Error: email: cannot be blank; name: cannot be blank.
+```

--- a/docs/data/plugin-strconv-formatfloat.md
+++ b/docs/data/plugin-strconv-formatfloat.md
@@ -1,0 +1,38 @@
+---
+name: FormatFloat
+slug: formatfloat
+sourceRef: plugins/strconv/operator.go#L141
+type: plugin
+category: strconv
+signatures:
+  - "func FormatFloat(fmt byte, prec int, bitSize int)"
+playUrl: ""
+variantHelpers:
+  - plugin#strconv#formatfloat
+similarHelpers:
+  - plugin#strconv#formatint
+  - plugin#strconv#formatuint
+  - plugin#strconv#parsefloat
+position: 70
+---
+
+Converts each float64 emitted by the source Observable to its string representation using the given format and precision.
+
+```go
+import (
+    "github.com/samber/ro"
+    rostrconv "github.com/samber/ro/plugins/strconv"
+)
+
+obs := ro.Pipe[float64, string](
+    ro.Just(3.14159, 2.71828),
+    rostrconv.FormatFloat('f', 2, 64),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[string]())
+defer sub.Unsubscribe()
+
+// Next: 3.14
+// Next: 2.72
+// Completed
+```

--- a/docs/data/plugin-strconv-formatint.md
+++ b/docs/data/plugin-strconv-formatint.md
@@ -1,0 +1,40 @@
+---
+name: FormatInt
+slug: formatint
+sourceRef: plugins/strconv/operator.go#L176
+type: plugin
+category: strconv
+signatures:
+  - "func FormatInt[T ~string](base int)"
+playUrl: ""
+variantHelpers:
+  - plugin#strconv#formatint
+similarHelpers:
+  - plugin#strconv#formatuint
+  - plugin#strconv#formatfloat
+  - plugin#strconv#parseint
+  - plugin#strconv#itoa
+position: 80
+---
+
+Converts each int64 emitted by the source Observable to its string representation in the given base.
+
+```go
+import (
+    "github.com/samber/ro"
+    rostrconv "github.com/samber/ro/plugins/strconv"
+)
+
+obs := ro.Pipe[int64, string](
+    ro.Just[int64](255, 16, 8),
+    rostrconv.FormatInt[string](16),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[string]())
+defer sub.Unsubscribe()
+
+// Next: ff
+// Next: 10
+// Next: 8
+// Completed
+```

--- a/docs/data/plugin-strconv-formatuint.md
+++ b/docs/data/plugin-strconv-formatuint.md
@@ -1,0 +1,39 @@
+---
+name: FormatUint
+slug: formatuint
+sourceRef: plugins/strconv/operator.go#L190
+type: plugin
+category: strconv
+signatures:
+  - "func FormatUint[T ~string](base int)"
+playUrl: ""
+variantHelpers:
+  - plugin#strconv#formatuint
+similarHelpers:
+  - plugin#strconv#formatint
+  - plugin#strconv#formatfloat
+  - plugin#strconv#parseuint
+position: 90
+---
+
+Converts each uint64 emitted by the source Observable to its string representation in the given base.
+
+```go
+import (
+    "github.com/samber/ro"
+    rostrconv "github.com/samber/ro/plugins/strconv"
+)
+
+obs := ro.Pipe[uint64, string](
+    ro.Just[uint64](255, 1024, 0),
+    rostrconv.FormatUint[string](2),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[string]())
+defer sub.Unsubscribe()
+
+// Next: 11111111
+// Next: 10000000000
+// Next: 0
+// Completed
+```

--- a/docs/data/plugin-strings-pascalcase.md
+++ b/docs/data/plugin-strings-pascalcase.md
@@ -1,0 +1,40 @@
+---
+name: PascalCase
+slug: pascalcase
+sourceRef: plugins/strings/operator_pascalcase.go#L33
+type: plugin
+category: strings
+signatures:
+  - "func PascalCase[T ~string]()"
+playUrl: ""
+variantHelpers:
+  - plugin#strings#pascalcase
+similarHelpers:
+  - plugin#strings#camelcase
+  - plugin#strings#snakecase
+  - plugin#strings#kebabcase
+  - plugin#bytes#pascalcase
+position: 5
+---
+
+Converts each string emitted by the source Observable to PascalCase (UpperCamelCase).
+
+```go
+import (
+    "github.com/samber/ro"
+    rostrings "github.com/samber/ro/plugins/strings"
+)
+
+obs := ro.Pipe[string, string](
+    ro.Just("hello_world", "foo-bar", "some string"),
+    rostrings.PascalCase[string](),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[string]())
+defer sub.Unsubscribe()
+
+// Next: HelloWorld
+// Next: FooBar
+// Next: SomeString
+// Completed
+```

--- a/docs/data/plugin-time-add.md
+++ b/docs/data/plugin-time-add.md
@@ -1,0 +1,55 @@
+---
+name: Add
+slug: add
+sourceRef: plugins/time/operator_add.go#L33
+type: plugin
+category: time
+signatures:
+  - "func Add(d time.Duration)"
+  - "func AddDate(years int, months int, days int)"
+playUrl: ""
+variantHelpers:
+  - plugin#time#add
+  - plugin#time#adddate
+similarHelpers:
+  - plugin#time#startofday
+  - plugin#time#in
+position: 20
+---
+
+Adds a duration or date offset to each time.Time emitted by the source Observable.
+
+```go
+import (
+    "time"
+
+    "github.com/samber/ro"
+    rotime "github.com/samber/ro/plugins/time"
+)
+
+obs := ro.Pipe[time.Time, time.Time](
+    ro.Just(time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)),
+    rotime.Add(24 * time.Hour),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[time.Time]())
+defer sub.Unsubscribe()
+
+// Next: 2024-01-16 12:00:00 +0000 UTC
+// Completed
+```
+
+### AddDate
+
+```go
+obs := ro.Pipe[time.Time, time.Time](
+    ro.Just(time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)),
+    rotime.AddDate(1, 2, 3),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[time.Time]())
+defer sub.Unsubscribe()
+
+// Next: 2025-03-18 00:00:00 +0000 UTC
+// Completed
+```

--- a/docs/data/plugin-time-format.md
+++ b/docs/data/plugin-time-format.md
@@ -1,0 +1,41 @@
+---
+name: Format
+slug: format
+sourceRef: plugins/time/operator_format.go#L33
+type: plugin
+category: time
+signatures:
+  - "func Format(format string)"
+playUrl: ""
+variantHelpers:
+  - plugin#time#format
+similarHelpers:
+  - plugin#time#parse
+position: 10
+---
+
+Formats each time.Time emitted by the source Observable into a string using the given layout.
+
+```go
+import (
+    "time"
+
+    "github.com/samber/ro"
+    rotime "github.com/samber/ro/plugins/time"
+)
+
+obs := ro.Pipe[time.Time, string](
+    ro.Just(
+        time.Date(2024, 1, 15, 12, 30, 0, 0, time.UTC),
+        time.Date(2024, 6, 20, 8, 0, 0, 0, time.UTC),
+    ),
+    rotime.Format("2006-01-02"),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[string]())
+defer sub.Unsubscribe()
+
+// Next: 2024-01-15
+// Next: 2024-06-20
+// Completed
+```

--- a/docs/data/plugin-time-in.md
+++ b/docs/data/plugin-time-in.md
@@ -1,0 +1,40 @@
+---
+name: In
+slug: in
+sourceRef: plugins/time/operator_in_time_zone.go#L35
+type: plugin
+category: time
+signatures:
+  - "func In(loc *time.Location)"
+playUrl: ""
+variantHelpers:
+  - plugin#time#in
+similarHelpers:
+  - plugin#time#startofday
+  - plugin#time#add
+position: 30
+---
+
+Converts each time.Time emitted by the source Observable to the given time zone location.
+
+```go
+import (
+    "time"
+
+    "github.com/samber/ro"
+    rotime "github.com/samber/ro/plugins/time"
+)
+
+loc, _ := time.LoadLocation("America/New_York")
+
+obs := ro.Pipe[time.Time, time.Time](
+    ro.Just(time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)),
+    rotime.In(loc),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[time.Time]())
+defer sub.Unsubscribe()
+
+// Next: 2024-01-15 07:00:00 -0500 EST
+// Completed
+```

--- a/docs/data/plugin-time-parse.md
+++ b/docs/data/plugin-time-parse.md
@@ -1,0 +1,57 @@
+---
+name: Parse
+slug: parse
+sourceRef: plugins/time/operator_parse.go#L33
+type: plugin
+category: time
+signatures:
+  - "func Parse[T ~string](layout string)"
+  - "func ParseInLocation[T ~string](layout string, loc *time.Location)"
+playUrl: ""
+variantHelpers:
+  - plugin#time#parse
+  - plugin#time#parseinlocation
+similarHelpers:
+  - plugin#time#format
+position: 0
+---
+
+Parses string values emitted by the source Observable into time.Time using the given layout.
+
+```go
+import (
+    "time"
+
+    "github.com/samber/ro"
+    rotime "github.com/samber/ro/plugins/time"
+)
+
+obs := ro.Pipe[string, time.Time](
+    ro.Just("2024-01-15", "2024-06-20"),
+    rotime.Parse[string]("2006-01-02"),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[time.Time]())
+defer sub.Unsubscribe()
+
+// Next: 2024-01-15 00:00:00 +0000 UTC
+// Next: 2024-06-20 00:00:00 +0000 UTC
+// Completed
+```
+
+### ParseInLocation
+
+```go
+loc, _ := time.LoadLocation("America/New_York")
+
+obs := ro.Pipe[string, time.Time](
+    ro.Just("2024-01-15 10:00:00"),
+    rotime.ParseInLocation[string]("2006-01-02 15:04:05", loc),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[time.Time]())
+defer sub.Unsubscribe()
+
+// Next: 2024-01-15 10:00:00 -0500 EST
+// Completed
+```

--- a/docs/data/plugin-time-startofday.md
+++ b/docs/data/plugin-time-startofday.md
@@ -1,0 +1,42 @@
+---
+name: StartOfDay
+slug: startofday
+sourceRef: plugins/time/operator_start_of_day.go#L33
+type: plugin
+category: time
+signatures:
+  - "func StartOfDay()"
+playUrl: ""
+variantHelpers:
+  - plugin#time#startofday
+similarHelpers:
+  - plugin#time#in
+  - plugin#time#add
+position: 40
+---
+
+Truncates each time.Time emitted by the source Observable to midnight (00:00:00) of the same day and location.
+
+```go
+import (
+    "time"
+
+    "github.com/samber/ro"
+    rotime "github.com/samber/ro/plugins/time"
+)
+
+obs := ro.Pipe[time.Time, time.Time](
+    ro.Just(
+        time.Date(2024, 1, 15, 14, 30, 45, 0, time.UTC),
+        time.Date(2024, 6, 20, 8, 15, 0, 0, time.UTC),
+    ),
+    rotime.StartOfDay(),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[time.Time]())
+defer sub.Unsubscribe()
+
+// Next: 2024-01-15 00:00:00 +0000 UTC
+// Next: 2024-06-20 00:00:00 +0000 UTC
+// Completed
+```

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -196,14 +196,17 @@ observable.Subscribe(ro.OnNext(func(s string) {
 - `ToSlice` - Collect all items into a slice
 - `ToMap` - Collect items into a map
 - `ToChannel` - Forward items to a channel
+- `Collect` - Collect all items into a slice (blocking)
+- `CollectWithContext` - Collect all items with context propagation (blocking)
 
 ## Available Plugins
 
 ### Data Manipulation
 - **bytes** - Byte slice manipulation operators
-- **strings** - String manipulation operators (Capitalize, CamelCase, SnakeCase, etc.)
+- **strings** - String manipulation operators (Capitalize, PascalCase, CamelCase, SnakeCase, etc.)
+- **strconv** - String conversion operators (FormatFloat, FormatInt, FormatUint, etc.)
 - **sort** - Sorting operators
-- **time** - Time manipulation
+- **time** - Time manipulation operators (Add, AddDate, In, Format, Parse, ParseInLocation, StartOfDay)
 - **exp/simd** - SIMD-accelerated math operators (Add, Sub, Min, Max, Clamp...)
 
 ### Encoding & Serialization


### PR DESCRIPTION
## Summary

Audit of the repository revealed **15 undocumented core operators** and **13 undocumented plugin operators**. This PR adds a dedicated documentation file for each, fixes stale cross-references in existing docs, and updates `llms.txt`.

### New core operator docs (15)

| File | Operator(s) | Category |
|------|-------------|----------|
| `core-cast.md` | `Cast` | transformation |
| `core-collect.md` | `Collect`, `CollectWithContext` | sink |
| `core-delayeach.md` | `DelayEach` | utility |
| `core-endwith.md` | `EndWith` | combining |
| `core-flatten.md` | `Flatten` | transformation |
| `core-mapto.md` | `MapTo` | transformation |
| `core-repeatwith.md` | `RepeatWith` | utility |
| `core-sampletime.md` | `SampleTime` | transformation |
| `core-samplewhen.md` | `SampleWhen` | transformation |
| `core-skiplast.md` | `SkipLast` | filtering |
| `core-skipuntil.md` | `SkipUntil` | filtering |
| `core-takeuntil.md` | `TakeUntil` | filtering |
| `core-throttletime.md` | `ThrottleTime` | transformation |
| `core-throttlewhen.md` | `ThrottleWhen` | transformation |
| `core-trunc.md` | `Trunc` | math |

### New plugin operator docs (13)

| File | Operator(s) | Plugin |
|------|-------------|--------|
| `plugin-time-add.md` | `Add`, `AddDate` | time |
| `plugin-time-format.md` | `Format` | time |
| `plugin-time-in.md` | `In` | time |
| `plugin-time-parse.md` | `Parse`, `ParseInLocation` | time |
| `plugin-time-startofday.md` | `StartOfDay` | time |
| `plugin-strings-pascalcase.md` | `PascalCase` | strings |
| `plugin-strconv-formatfloat.md` | `FormatFloat` | strconv |
| `plugin-strconv-formatint.md` | `FormatInt` | strconv |
| `plugin-strconv-formatuint.md` | `FormatUint` | strconv |
| `plugin-observability-slog-logwithnotification.md` | `LogWithNotification` | observability/slog |
| `plugin-ozzo-validation-validateorerrorwithcontext.md` | `ValidateOrErrorWithContext` | ozzo-validation |
| `plugin-ozzo-validation-validatestructorerror.md` | `ValidateStructOrError` | ozzo-validation |
| `plugin-ozzo-validation-validatestructorerrorwithcontext.md` | `ValidateStructOrErrorWithContext` | ozzo-validation |

### Fixes to existing docs (9 files)

- **`core-map.md`** — trailing comma bug in `similarHelpers` slugs
- **`core-skip.md`** — add `skiplast` and `skipuntil` to `similarHelpers`
- **`core-repeat.md`** — add `repeatwith` to `similarHelpers`
- **`core-flatmap.md`** — add `flatten` to `similarHelpers`
- **`core-tochannel.md`** — remove non-existent `tochannelwithcontext` from `variantHelpers`
- **`core-contextwithdeadline.md`** — remove ghost `ContextWithDeadlineCause` (function is commented out in source)
- **`core-contextwithtimeout.md`** — remove ghost `ContextWithTimeoutCause` (function is commented out in source)
- **`plugin-ozzo-validation-validateorerror.md`** — link `validateorerrorwithcontext` in `similarHelpers`
- **`docs/static/llms.txt`** — add all new operators and the time plugin entry