### PR TITLE
feat: add WithLanguage variants for case-conversion operators (strings + bytes plugins)

### DIFF
--- a/docs/data/plugin-bytes-camelcase.md
+++ b/docs/data/plugin-bytes-camelcase.md
@@ -6,9 +6,11 @@ type: plugin
 category: bytes
 signatures:
   - "func CamelCase[T ~[]byte]()"
+  - "func CamelCaseWithLanguage[T ~[]byte](tag language.Tag)"
 playUrl: https://go.dev/play/p/RCL_Z45aIQC
 variantHelpers:
   - plugin#bytes#camelcase
+  - plugin#bytes#camelcasewithlanguage
 similarHelpers:
   - plugin#strings#camelcase
 position: 0
@@ -31,5 +33,28 @@ sub := obs.Subscribe(ro.PrintObserver[[]byte]())
 defer sub.Unsubscribe()
 
 // Next: [104 101 108 108 111 87 111 114 108 100 87 111 114 108 100]
+// Completed
+```
+
+### CamelCaseWithLanguage
+
+Converts the string to camel case using locale-aware casing.
+
+```go
+import (
+    "github.com/samber/ro"
+    robytes "github.com/samber/ro/plugins/bytes"
+    "golang.org/x/text/language"
+)
+
+obs := ro.Pipe[[]byte, []byte](
+    ro.Just([]byte("Istanbul city")),
+    robytes.CamelCaseWithLanguage[[]byte](language.Turkish),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[[]byte]())
+defer sub.Unsubscribe()
+
+// Next: [196 177 115 116 97 110 98 117 108 67 105 116 121]
 // Completed
 ```

--- a/docs/data/plugin-bytes-capitalize.md
+++ b/docs/data/plugin-bytes-capitalize.md
@@ -6,9 +6,11 @@ type: plugin
 category: bytes
 signatures:
   - "func Capitalize[T ~[]byte]()"
+  - "func CapitalizeWithLanguage[T ~[]byte](tag language.Tag)"
 playUrl: https://go.dev/play/p/qc7UDCtJM0n
 variantHelpers:
   - plugin#bytes#capitalize
+  - plugin#bytes#capitalizewithlanguage
 similarHelpers:
   - plugin#strings#capitalize
 position: 20
@@ -31,5 +33,28 @@ sub := obs.Subscribe(ro.PrintObserver[[]byte]())
 defer sub.Unsubscribe()
 
 // Next: [72 101 108 108 111 32 119 111 114 108 100]
+// Completed
+```
+
+### CapitalizeWithLanguage
+
+Capitalizes the first letter using locale-aware casing.
+
+```go
+import (
+    "github.com/samber/ro"
+    robytes "github.com/samber/ro/plugins/bytes"
+    "golang.org/x/text/language"
+)
+
+obs := ro.Pipe[[]byte, []byte](
+    ro.Just([]byte("istanbul")),
+    robytes.CapitalizeWithLanguage[[]byte](language.Turkish),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[[]byte]())
+defer sub.Unsubscribe()
+
+// Next: [196 176 115 116 97 110 98 117 108]
 // Completed
 ```

--- a/docs/data/plugin-bytes-kebabcase.md
+++ b/docs/data/plugin-bytes-kebabcase.md
@@ -6,9 +6,11 @@ type: plugin
 category: bytes
 signatures:
   - "func KebabCase[T ~[]byte]()"
+  - "func KebabCaseWithLanguage[T ~[]byte](tag language.Tag)"
 playUrl: https://go.dev/play/p/86V3xKuLykG
 variantHelpers:
   - plugin#bytes#kebabcase
+  - plugin#bytes#kebabcasewithlanguage
 similarHelpers: []
 position: 10
 ---
@@ -30,5 +32,28 @@ sub := obs.Subscribe(ro.PrintObserver[[]byte]())
 defer sub.Unsubscribe()
 
 // Next: [104 101 108 108 111 45 119 111 114 108 100 45 119 111 114 108 100]
+// Completed
+```
+
+### KebabCaseWithLanguage
+
+Converts the string to kebab case using locale-aware casing.
+
+```go
+import (
+    "github.com/samber/ro"
+    robytes "github.com/samber/ro/plugins/bytes"
+    "golang.org/x/text/language"
+)
+
+obs := ro.Pipe[[]byte, []byte](
+    ro.Just([]byte("IstanbulCity")),
+    robytes.KebabCaseWithLanguage[[]byte](language.Turkish),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[[]byte]())
+defer sub.Unsubscribe()
+
+// Next: [196 177 115 116 97 110 98 117 108 45 99 105 116 121]
 // Completed
 ```

--- a/docs/data/plugin-bytes-pascalcase.md
+++ b/docs/data/plugin-bytes-pascalcase.md
@@ -6,9 +6,11 @@ type: plugin
 category: bytes
 signatures:
   - "func PascalCase[T ~[]byte]()"
+  - "func PascalCaseWithLanguage[T ~[]byte](tag language.Tag)"
 playUrl: https://go.dev/play/p/ToPLTi_lCXI
 variantHelpers:
   - plugin#bytes#pascalcase
+  - plugin#bytes#pascalcasewithlanguage
 similarHelpers:
   - plugin#strings#pascalcase
 position: 40
@@ -31,5 +33,28 @@ sub := obs.Subscribe(ro.PrintObserver[[]byte]())
 defer sub.Unsubscribe()
 
 // Next: [72 101 108 108 111 87 111 114 108 100 87 111 114 108 100]
+// Completed
+```
+
+### PascalCaseWithLanguage
+
+Converts the string to pascal case using locale-aware casing.
+
+```go
+import (
+    "github.com/samber/ro"
+    robytes "github.com/samber/ro/plugins/bytes"
+    "golang.org/x/text/language"
+)
+
+obs := ro.Pipe[[]byte, []byte](
+    ro.Just([]byte("istanbul city")),
+    robytes.PascalCaseWithLanguage[[]byte](language.Turkish),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[[]byte]())
+defer sub.Unsubscribe()
+
+// Next: [196 176 115 116 97 110 98 117 108 67 105 116 121]
 // Completed
 ```

--- a/docs/data/plugin-bytes-snakecase.md
+++ b/docs/data/plugin-bytes-snakecase.md
@@ -6,9 +6,11 @@ type: plugin
 category: bytes
 signatures:
   - "func SnakeCase[T ~[]byte]()"
+  - "func SnakeCaseWithLanguage[T ~[]byte](tag language.Tag)"
 playUrl: https://go.dev/play/p/JSlMzOne811
 variantHelpers:
   - plugin#bytes#snakecase
+  - plugin#bytes#snakecasewithlanguage
 similarHelpers:
   - plugin#strings#snakecase
 position: 60
@@ -31,5 +33,28 @@ sub := obs.Subscribe(ro.PrintObserver[[]byte]())
 defer sub.Unsubscribe()
 
 // Next: [104 101 108 108 111 95 119 111 114 108 100 95 119 111 114 108 100]
+// Completed
+```
+
+### SnakeCaseWithLanguage
+
+Converts the string to snake case using locale-aware casing.
+
+```go
+import (
+    "github.com/samber/ro"
+    robytes "github.com/samber/ro/plugins/bytes"
+    "golang.org/x/text/language"
+)
+
+obs := ro.Pipe[[]byte, []byte](
+    ro.Just([]byte("IstanbulCity")),
+    robytes.SnakeCaseWithLanguage[[]byte](language.Turkish),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[[]byte]())
+defer sub.Unsubscribe()
+
+// Next: [196 177 115 116 97 110 98 117 108 95 99 105 116 121]
 // Completed
 ```

--- a/docs/data/plugin-strings-camelcase.md
+++ b/docs/data/plugin-strings-camelcase.md
@@ -6,9 +6,11 @@ type: plugin
 category: strings
 signatures:
   - "func CamelCase[T ~string]()"
+  - "func CamelCaseWithLanguage[T ~string](tag language.Tag)"
 playUrl: https://go.dev/play/p/65rbW1kFxhF
 variantHelpers:
   - plugin#strings#camelcase
+  - plugin#strings#camelcasewithlanguage
 similarHelpers:
   - plugin#bytes#camelcase
 position: 0
@@ -31,5 +33,28 @@ sub := obs.Subscribe(ro.PrintObserver[string]())
 defer sub.Unsubscribe()
 
 // Next: helloWorldWorld
+// Completed
+```
+
+### CamelCaseWithLanguage
+
+Converts the string to camel case using locale-aware casing.
+
+```go
+import (
+    "github.com/samber/ro"
+    rostrings "github.com/samber/ro/plugins/strings"
+    "golang.org/x/text/language"
+)
+
+obs := ro.Pipe[string, string](
+    ro.Just("Istanbul city"),
+    rostrings.CamelCaseWithLanguage[string](language.Turkish),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[string]())
+defer sub.Unsubscribe()
+
+// Next: ıstanbulCity
 // Completed
 ```

--- a/docs/data/plugin-strings-capitalize.md
+++ b/docs/data/plugin-strings-capitalize.md
@@ -6,9 +6,11 @@ type: plugin
 category: strings
 signatures:
   - "func Capitalize[T ~string]()"
+  - "func CapitalizeWithLanguage[T ~string](tag language.Tag)"
 playUrl: https://go.dev/play/p/Q9lZAav_ETm
 variantHelpers:
   - plugin#strings#capitalize
+  - plugin#strings#capitalizewithlanguage
 similarHelpers:
   - plugin#bytes#capitalize
 position: 10
@@ -31,5 +33,28 @@ sub := obs.Subscribe(ro.PrintObserver[string]())
 defer sub.Unsubscribe()
 
 // Next: Hello world
+// Completed
+```
+
+### CapitalizeWithLanguage
+
+Capitalizes the first letter using locale-aware casing.
+
+```go
+import (
+    "github.com/samber/ro"
+    rostrings "github.com/samber/ro/plugins/strings"
+    "golang.org/x/text/language"
+)
+
+obs := ro.Pipe[string, string](
+    ro.Just("istanbul"),
+    rostrings.CapitalizeWithLanguage[string](language.Turkish),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[string]())
+defer sub.Unsubscribe()
+
+// Next: İstanbul
 // Completed
 ```

--- a/docs/data/plugin-strings-kebabcase.md
+++ b/docs/data/plugin-strings-kebabcase.md
@@ -6,9 +6,11 @@ type: plugin
 category: strings
 signatures:
   - "func KebabCase[T ~string]()"
+  - "func KebabCaseWithLanguage[T ~string](tag language.Tag)"
 playUrl: https://go.dev/play/p/yAbSRKFl4pS
 variantHelpers:
   - plugin#strings#kebabcase
+  - plugin#strings#kebabcasewithlanguage
 similarHelpers:
   - plugin#strings#snakecase
   - plugin#strings#camelcase
@@ -32,5 +34,28 @@ sub := obs.Subscribe(ro.PrintObserver[string]())
 defer sub.Unsubscribe()
 
 // Next: hello-world-test
+// Completed
+```
+
+### KebabCaseWithLanguage
+
+Converts the string to kebab case using locale-aware casing.
+
+```go
+import (
+    "github.com/samber/ro"
+    rostrings "github.com/samber/ro/plugins/strings"
+    "golang.org/x/text/language"
+)
+
+obs := ro.Pipe[string, string](
+    ro.Just("IstanbulCity"),
+    rostrings.KebabCaseWithLanguage[string](language.Turkish),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[string]())
+defer sub.Unsubscribe()
+
+// Next: ıstanbul-city
 // Completed
 ```

--- a/docs/data/plugin-strings-pascalcase.md
+++ b/docs/data/plugin-strings-pascalcase.md
@@ -1,14 +1,16 @@
 ---
 name: PascalCase
 slug: pascalcase
-sourceRef: plugins/strings/operator_pascalcase.go#L33
+sourceRef: plugins/strings/operator_pascalcase.go#L47
 type: plugin
 category: strings
 signatures:
   - "func PascalCase[T ~string]()"
-playUrl: ""
+  - "func PascalCaseWithLanguage[T ~string](tag language.Tag)"
+playUrl: https://go.dev/play/p/107SvPGvHAK
 variantHelpers:
   - plugin#strings#pascalcase
+  - plugin#strings#pascalcasewithlanguage
 similarHelpers:
   - plugin#strings#camelcase
   - plugin#strings#snakecase
@@ -36,5 +38,28 @@ defer sub.Unsubscribe()
 // Next: HelloWorld
 // Next: FooBar
 // Next: SomeString
+// Completed
+```
+
+### PascalCaseWithLanguage
+
+Converts the string to pascal case using locale-aware casing.
+
+```go
+import (
+    "github.com/samber/ro"
+    rostrings "github.com/samber/ro/plugins/strings"
+    "golang.org/x/text/language"
+)
+
+obs := ro.Pipe[string, string](
+    ro.Just("istanbul city"),
+    rostrings.PascalCaseWithLanguage[string](language.Turkish),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[string]())
+defer sub.Unsubscribe()
+
+// Next: İstanbulCity
 // Completed
 ```

--- a/docs/data/plugin-strings-snakecase.md
+++ b/docs/data/plugin-strings-snakecase.md
@@ -6,9 +6,11 @@ type: plugin
 category: strings
 signatures:
   - "func SnakeCase[T ~string]()"
+  - "func SnakeCaseWithLanguage[T ~string](tag language.Tag)"
 playUrl: https://go.dev/play/p/zHCGH586_X3
 variantHelpers:
   - plugin#strings#snakecase
+  - plugin#strings#snakecasewithlanguage
 similarHelpers:
   - plugin#bytes#snakecase
 position: 40
@@ -31,5 +33,28 @@ sub := obs.Subscribe(ro.PrintObserver[string]())
 defer sub.Unsubscribe()
 
 // Next: hello_world_world
+// Completed
+```
+
+### SnakeCaseWithLanguage
+
+Converts the string to snake case using locale-aware casing.
+
+```go
+import (
+    "github.com/samber/ro"
+    rostrings "github.com/samber/ro/plugins/strings"
+    "golang.org/x/text/language"
+)
+
+obs := ro.Pipe[string, string](
+    ro.Just("IstanbulCity"),
+    rostrings.SnakeCaseWithLanguage[string](language.Turkish),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[string]())
+defer sub.Unsubscribe()
+
+// Next: ıstanbul_city
 // Completed
 ```

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -203,7 +203,7 @@ observable.Subscribe(ro.OnNext(func(s string) {
 
 ### Data Manipulation
 - **bytes** - Byte slice manipulation operators
-- **strings** - String manipulation operators (Capitalize, PascalCase, CamelCase, SnakeCase, etc.)
+- **strings** - String manipulation operators (Capitalize, PascalCase, CamelCase, SnakeCase, etc.) with locale-aware WithLanguage variants
 - **strconv** - String conversion operators (FormatFloat, FormatInt, FormatUint, etc.)
 - **sort** - Sorting operators
 - **time** - Time manipulation operators (Add, AddDate, In, Format, Parse, ParseInLocation, StartOfDay)

--- a/plugins/bytes/operator_camelcase.go
+++ b/plugins/bytes/operator_camelcase.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 
 	"github.com/samber/ro"
+	"golang.org/x/text/language"
 )
 
 func toCamelCase(str []byte) []byte {
@@ -32,12 +33,37 @@ func toCamelCase(str []byte) []byte {
 	return bytes.Join(items, []byte(""))
 }
 
+func toCamelCaseWithLanguage(str []byte, tag language.Tag) []byte {
+	items := words(str)
+	if len(items) == 0 {
+		return []byte{}
+	}
+	lPool, lc := acquireLowerCaser(tag)
+	tPool, tc := acquireTitleCaser(tag)
+	defer lPool.Put(lc)
+	defer tPool.Put(tc)
+	items[0] = lc.Bytes(items[0])
+	for i := 1; i < len(items); i++ {
+		items[i] = tc.Bytes(items[i])
+	}
+	return bytes.Join(items, []byte(""))
+}
+
 // CamelCase converts the string to camel case.
 // Play: https://go.dev/play/p/ela3Jx8QQQL
 func CamelCase[T ~[]byte]() func(destination ro.Observable[T]) ro.Observable[T] {
 	return ro.Map(
 		func(value T) T {
 			return T(toCamelCase(value))
+		},
+	)
+}
+
+// CamelCaseWithLanguage converts the byte slice to camel case using locale-aware casing.
+func CamelCaseWithLanguage[T ~[]byte](tag language.Tag) func(destination ro.Observable[T]) ro.Observable[T] {
+	return ro.Map(
+		func(value T) T {
+			return T(toCamelCaseWithLanguage(value, tag))
 		},
 	)
 }

--- a/plugins/bytes/operator_camelcase_test.go
+++ b/plugins/bytes/operator_camelcase_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/samber/ro"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
 )
 
 func TestCamelCase(t *testing.T) {
@@ -33,7 +34,7 @@ func TestCamelCase(t *testing.T) {
 			),
 		)
 		is.Equal([]byte(t.output.CamelCase), values[0])
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -42,7 +43,7 @@ func TestCamelCase(t *testing.T) {
 			),
 		)
 		is.Equal([][]byte{}, values)
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -53,4 +54,48 @@ func TestCamelCase(t *testing.T) {
 		is.Equal([][]byte{}, values)
 		is.EqualError(err, assert.AnError.Error())
 	}
+}
+
+func TestCamelCaseWithLanguage(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	tests := []struct {
+		input []byte
+		tag   language.Tag
+		want  []byte
+	}{
+		{[]byte("hello world"), language.English, []byte("helloWorld")},
+		// Turkish: first word 'I' lowercases to 'ı'; 'c' title-cases to 'C'
+		{[]byte("Istanbul city"), language.Turkish, []byte("ıstanbulCity")},
+	}
+
+	for _, tc := range tests {
+		values, err := ro.Collect(
+			ro.Pipe1(
+				ro.Just(tc.input),
+				CamelCaseWithLanguage[[]byte](tc.tag),
+			),
+		)
+		is.Equal(tc.want, values[0])
+		is.NoError(err)
+	}
+
+	values, err := ro.Collect(
+		ro.Pipe1(
+			ro.Empty[[]byte](),
+			CamelCaseWithLanguage[[]byte](language.English),
+		),
+	)
+	is.Equal([][]byte{}, values)
+	is.NoError(err)
+
+	values, err = ro.Collect(
+		ro.Pipe1(
+			ro.Throw[[]byte](assert.AnError),
+			CamelCaseWithLanguage[[]byte](language.English),
+		),
+	)
+	is.Equal([][]byte{}, values)
+	is.EqualError(err, assert.AnError.Error())
 }

--- a/plugins/bytes/operator_capitalize.go
+++ b/plugins/bytes/operator_capitalize.go
@@ -22,19 +22,58 @@ import (
 	"golang.org/x/text/language"
 )
 
-// titleCaserPool reuses cases.Title casers: constructing one is far more
-// expensive than the casing itself, and a Caser is not safe for concurrent
-// use, so it cannot be a plain package-level singleton.
-var titleCaserPool = sync.Pool{
-	New: func() any {
-		c := cases.Title(language.English)
-		return &c
-	},
+// Dedicated English pools are cheaper than looking up the sync.Map each time.
+var (
+	englishTitleCaserPool = sync.Pool{New: func() any { c := cases.Title(language.English); return &c }}
+	englishLowerCaserPool = sync.Pool{New: func() any { c := cases.Lower(language.English); return &c }}
+
+	titleCaserPools sync.Map // map[string]*sync.Pool  (BCP 47 tag → pool of *cases.Caser)
+	lowerCaserPools sync.Map // map[string]*sync.Pool
+)
+
+func acquireTitleCaser(tag language.Tag) (*sync.Pool, *cases.Caser) {
+	key := tag.String()
+	if v, ok := titleCaserPools.Load(key); ok {
+		pool, _ := v.(*sync.Pool)
+		c, _ := pool.Get().(*cases.Caser)
+		return pool, c
+	}
+	p := &sync.Pool{New: func() any { c := cases.Title(tag); return &c }}
+	actual, _ := titleCaserPools.LoadOrStore(key, p)
+	pool, _ := actual.(*sync.Pool)
+	c, _ := pool.Get().(*cases.Caser)
+	return pool, c
+}
+
+func acquireLowerCaser(tag language.Tag) (*sync.Pool, *cases.Caser) {
+	key := tag.String()
+	if v, ok := lowerCaserPools.Load(key); ok {
+		pool, _ := v.(*sync.Pool)
+		c, _ := pool.Get().(*cases.Caser)
+		return pool, c
+	}
+	p := &sync.Pool{New: func() any { c := cases.Lower(tag); return &c }}
+	actual, _ := lowerCaserPools.LoadOrStore(key, p)
+	pool, _ := actual.(*sync.Pool)
+	c, _ := pool.Get().(*cases.Caser)
+	return pool, c
 }
 
 func capitalize(str []byte) []byte {
-	c, _ := titleCaserPool.Get().(*cases.Caser) // Pool.New always returns *cases.Caser, so the assertion never fails.
-	defer titleCaserPool.Put(c)
+	c, _ := englishTitleCaserPool.Get().(*cases.Caser)
+	defer englishTitleCaserPool.Put(c)
+	return c.Bytes(str)
+}
+
+func lowerEnglish(str []byte) []byte {
+	c, _ := englishLowerCaserPool.Get().(*cases.Caser)
+	defer englishLowerCaserPool.Put(c)
+	return c.Bytes(str)
+}
+
+func capitalizeWithLanguage(str []byte, tag language.Tag) []byte {
+	pool, c := acquireTitleCaser(tag)
+	defer pool.Put(c)
 	return c.Bytes(str)
 }
 
@@ -44,6 +83,15 @@ func Capitalize[T ~[]byte]() func(destination ro.Observable[T]) ro.Observable[T]
 	return ro.Map(
 		func(value T) T {
 			return T(capitalize(value))
+		},
+	)
+}
+
+// CapitalizeWithLanguage capitalizes the first letter of the byte slice using locale-aware casing.
+func CapitalizeWithLanguage[T ~[]byte](tag language.Tag) func(destination ro.Observable[T]) ro.Observable[T] {
+	return ro.Map(
+		func(value T) T {
+			return T(capitalizeWithLanguage(value, tag))
 		},
 	)
 }

--- a/plugins/bytes/operator_capitalize_test.go
+++ b/plugins/bytes/operator_capitalize_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/samber/ro"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
 )
 
 func TestCapitalize(t *testing.T) {
@@ -49,7 +50,7 @@ func TestCapitalize(t *testing.T) {
 			),
 		)
 		is.Equal([]byte(t.want), values[0])
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -58,7 +59,7 @@ func TestCapitalize(t *testing.T) {
 			),
 		)
 		is.Equal([][]byte{}, values)
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -69,4 +70,49 @@ func TestCapitalize(t *testing.T) {
 		is.Equal([][]byte{}, values)
 		is.EqualError(err, assert.AnError.Error())
 	}
+}
+
+func TestCapitalizeWithLanguage(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	tests := []struct {
+		input []byte
+		tag   language.Tag
+		want  []byte
+	}{
+		{[]byte("hello"), language.English, []byte("Hello")},
+		{[]byte("heLLO"), language.English, []byte("Hello")},
+		// Turkish: 'i' title-cases to 'İ' (U+0130)
+		{[]byte("istanbul"), language.Turkish, []byte("İstanbul")},
+	}
+
+	for _, tc := range tests {
+		values, err := ro.Collect(
+			ro.Pipe1(
+				ro.Just(tc.input),
+				CapitalizeWithLanguage[[]byte](tc.tag),
+			),
+		)
+		is.Equal(tc.want, values[0])
+		is.NoError(err)
+	}
+
+	values, err := ro.Collect(
+		ro.Pipe1(
+			ro.Empty[[]byte](),
+			CapitalizeWithLanguage[[]byte](language.English),
+		),
+	)
+	is.Equal([][]byte{}, values)
+	is.NoError(err)
+
+	values, err = ro.Collect(
+		ro.Pipe1(
+			ro.Throw[[]byte](assert.AnError),
+			CapitalizeWithLanguage[[]byte](language.English),
+		),
+	)
+	is.Equal([][]byte{}, values)
+	is.EqualError(err, assert.AnError.Error())
 }

--- a/plugins/bytes/operator_case_test.go
+++ b/plugins/bytes/operator_case_test.go
@@ -39,7 +39,8 @@ var allCaseTests = []struct {
 			CamelCase:  "helloWorld",
 			KebabCase:  "hello-world",
 			SnakeCase:  "hello_world",
-		}},
+		},
+	},
 	{
 		input: "A",
 		output: caseTests{
@@ -47,7 +48,8 @@ var allCaseTests = []struct {
 			CamelCase:  "a",
 			KebabCase:  "a",
 			SnakeCase:  "a",
-		}},
+		},
+	},
 	{
 		input: "a",
 		output: caseTests{
@@ -55,7 +57,8 @@ var allCaseTests = []struct {
 			CamelCase:  "a",
 			KebabCase:  "a",
 			SnakeCase:  "a",
-		}},
+		},
+	},
 	{
 		input: "foo",
 		output: caseTests{
@@ -63,7 +66,8 @@ var allCaseTests = []struct {
 			CamelCase:  "foo",
 			KebabCase:  "foo",
 			SnakeCase:  "foo",
-		}},
+		},
+	},
 	{
 		input: "snake_case",
 		output: caseTests{
@@ -71,7 +75,8 @@ var allCaseTests = []struct {
 			CamelCase:  "snakeCase",
 			KebabCase:  "snake-case",
 			SnakeCase:  "snake_case",
-		}},
+		},
+	},
 	{
 		input: "SNAKE_CASE",
 		output: caseTests{
@@ -79,7 +84,8 @@ var allCaseTests = []struct {
 			CamelCase:  "snakeCase",
 			KebabCase:  "snake-case",
 			SnakeCase:  "snake_case",
-		}},
+		},
+	},
 	{
 		input: "kebab-case",
 		output: caseTests{
@@ -87,7 +93,8 @@ var allCaseTests = []struct {
 			CamelCase:  "kebabCase",
 			KebabCase:  "kebab-case",
 			SnakeCase:  "kebab_case",
-		}},
+		},
+	},
 	{
 		input: "PascalCase",
 		output: caseTests{
@@ -95,7 +102,8 @@ var allCaseTests = []struct {
 			CamelCase:  "pascalCase",
 			KebabCase:  "pascal-case",
 			SnakeCase:  "pascal_case",
-		}},
+		},
+	},
 	{
 		input: "camelCase",
 		output: caseTests{
@@ -103,7 +111,8 @@ var allCaseTests = []struct {
 			CamelCase:  "camelCase",
 			KebabCase:  `camel-case`,
 			SnakeCase:  "camel_case",
-		}},
+		},
+	},
 	{
 		input: "Title Case",
 		output: caseTests{
@@ -111,7 +120,8 @@ var allCaseTests = []struct {
 			CamelCase:  "titleCase",
 			KebabCase:  "title-case",
 			SnakeCase:  "title_case",
-		}},
+		},
+	},
 	{
 		input: "point.case",
 		output: caseTests{
@@ -119,7 +129,8 @@ var allCaseTests = []struct {
 			CamelCase:  "pointCase",
 			KebabCase:  "point-case",
 			SnakeCase:  "point_case",
-		}},
+		},
+	},
 	{
 		input: "snake_case_with_more_words",
 		output: caseTests{
@@ -127,7 +138,8 @@ var allCaseTests = []struct {
 			CamelCase:  "snakeCaseWithMoreWords",
 			KebabCase:  "snake-case-with-more-words",
 			SnakeCase:  "snake_case_with_more_words",
-		}},
+		},
+	},
 	{
 		input: "SNAKE_CASE_WITH_MORE_WORDS",
 		output: caseTests{
@@ -135,7 +147,8 @@ var allCaseTests = []struct {
 			CamelCase:  "snakeCaseWithMoreWords",
 			KebabCase:  "snake-case-with-more-words",
 			SnakeCase:  "snake_case_with_more_words",
-		}},
+		},
+	},
 	{
 		input: "kebab-case-with-more-words",
 		output: caseTests{
@@ -143,7 +156,8 @@ var allCaseTests = []struct {
 			CamelCase:  "kebabCaseWithMoreWords",
 			KebabCase:  "kebab-case-with-more-words",
 			SnakeCase:  "kebab_case_with_more_words",
-		}},
+		},
+	},
 	{
 		input: "PascalCaseWithMoreWords",
 		output: caseTests{
@@ -151,7 +165,8 @@ var allCaseTests = []struct {
 			CamelCase:  "pascalCaseWithMoreWords",
 			KebabCase:  "pascal-case-with-more-words",
 			SnakeCase:  "pascal_case_with_more_words",
-		}},
+		},
+	},
 	{
 		input: "camelCaseWithMoreWords",
 		output: caseTests{
@@ -159,7 +174,8 @@ var allCaseTests = []struct {
 			CamelCase:  "camelCaseWithMoreWords",
 			KebabCase:  "camel-case-with-more-words",
 			SnakeCase:  "camel_case_with_more_words",
-		}},
+		},
+	},
 	{
 		input: "Title Case With More Words",
 		output: caseTests{
@@ -167,7 +183,8 @@ var allCaseTests = []struct {
 			CamelCase:  "titleCaseWithMoreWords",
 			KebabCase:  "title-case-with-more-words",
 			SnakeCase:  "title_case_with_more_words",
-		}},
+		},
+	},
 	{
 		input: "point.case.with.more.words",
 		output: caseTests{
@@ -175,7 +192,8 @@ var allCaseTests = []struct {
 			CamelCase:  "pointCaseWithMoreWords",
 			KebabCase:  "point-case-with-more-words",
 			SnakeCase:  "point_case_with_more_words",
-		}},
+		},
+	},
 	{
 		input: "snake_case__with___multiple____delimiters",
 		output: caseTests{
@@ -183,7 +201,8 @@ var allCaseTests = []struct {
 			CamelCase:  "snakeCaseWithMultipleDelimiters",
 			KebabCase:  "snake-case-with-multiple-delimiters",
 			SnakeCase:  "snake_case_with_multiple_delimiters",
-		}},
+		},
+	},
 	{
 		input: "SNAKE_CASE__WITH___multiple____DELIMITERS",
 		output: caseTests{
@@ -191,7 +210,8 @@ var allCaseTests = []struct {
 			CamelCase:  "snakeCaseWithMultipleDelimiters",
 			KebabCase:  "snake-case-with-multiple-delimiters",
 			SnakeCase:  "snake_case_with_multiple_delimiters",
-		}},
+		},
+	},
 	{
 		input: "kebab-case--with---multiple----delimiters",
 		output: caseTests{
@@ -199,7 +219,8 @@ var allCaseTests = []struct {
 			CamelCase:  "kebabCaseWithMultipleDelimiters",
 			KebabCase:  "kebab-case-with-multiple-delimiters",
 			SnakeCase:  "kebab_case_with_multiple_delimiters",
-		}},
+		},
+	},
 	{
 		input: "Title Case  With   Multiple    Delimiters",
 		output: caseTests{
@@ -207,7 +228,8 @@ var allCaseTests = []struct {
 			CamelCase:  "titleCaseWithMultipleDelimiters",
 			KebabCase:  "title-case-with-multiple-delimiters",
 			SnakeCase:  "title_case_with_multiple_delimiters",
-		}},
+		},
+	},
 	{
 		input: "point.case..with...multiple....delimiters",
 		output: caseTests{
@@ -215,7 +237,8 @@ var allCaseTests = []struct {
 			CamelCase:  "pointCaseWithMultipleDelimiters",
 			KebabCase:  "point-case-with-multiple-delimiters",
 			SnakeCase:  "point_case_with_multiple_delimiters",
-		}},
+		},
+	},
 	{
 		input: " leading space",
 		output: caseTests{
@@ -223,7 +246,8 @@ var allCaseTests = []struct {
 			CamelCase:  "leadingSpace",
 			KebabCase:  "leading-space",
 			SnakeCase:  "leading_space",
-		}},
+		},
+	},
 	{
 		input: "   leading spaces",
 		output: caseTests{
@@ -231,7 +255,8 @@ var allCaseTests = []struct {
 			CamelCase:  "leadingSpaces",
 			KebabCase:  "leading-spaces",
 			SnakeCase:  "leading_spaces",
-		}},
+		},
+	},
 	{
 		input: "\t\t\r\n leading whitespaces",
 		output: caseTests{
@@ -239,7 +264,8 @@ var allCaseTests = []struct {
 			CamelCase:  "leadingWhitespaces",
 			KebabCase:  "leading-whitespaces",
 			SnakeCase:  "leading_whitespaces",
-		}},
+		},
+	},
 	{
 		input: "trailing space ",
 		output: caseTests{
@@ -247,7 +273,8 @@ var allCaseTests = []struct {
 			CamelCase:  "trailingSpace",
 			KebabCase:  "trailing-space",
 			SnakeCase:  "trailing_space",
-		}},
+		},
+	},
 	{
 		input: "trailing spaces   ",
 		output: caseTests{
@@ -255,7 +282,8 @@ var allCaseTests = []struct {
 			CamelCase:  "trailingSpaces",
 			KebabCase:  "trailing-spaces",
 			SnakeCase:  "trailing_spaces",
-		}},
+		},
+	},
 	{
 		input: "trailing whitespaces\t\t\r\n",
 		output: caseTests{
@@ -263,7 +291,8 @@ var allCaseTests = []struct {
 			CamelCase:  "trailingWhitespaces",
 			KebabCase:  "trailing-whitespaces",
 			SnakeCase:  "trailing_whitespaces",
-		}},
+		},
+	},
 	{
 		input: " on both sides ",
 		output: caseTests{
@@ -271,7 +300,8 @@ var allCaseTests = []struct {
 			CamelCase:  "onBothSides",
 			KebabCase:  "on-both-sides",
 			SnakeCase:  "on_both_sides",
-		}},
+		},
+	},
 	{
 		input: "    many on both sides  ",
 		output: caseTests{
@@ -279,7 +309,8 @@ var allCaseTests = []struct {
 			CamelCase:  "manyOnBothSides",
 			KebabCase:  "many-on-both-sides",
 			SnakeCase:  "many_on_both_sides",
-		}},
+		},
+	},
 	{
 		input: "\r whitespaces on both sides\t\t\r\n",
 		output: caseTests{
@@ -287,7 +318,8 @@ var allCaseTests = []struct {
 			CamelCase:  "whitespacesOnBothSides",
 			KebabCase:  "whitespaces-on-both-sides",
 			SnakeCase:  "whitespaces_on_both_sides",
-		}},
+		},
+	},
 	{
 		input: "  extraSpaces in_This TestCase Of MIXED_CASES\t",
 		output: caseTests{
@@ -295,7 +327,8 @@ var allCaseTests = []struct {
 			CamelCase:  "extraSpacesInThisTestCaseOfMixedCases",
 			KebabCase:  "extra-spaces-in-this-test-case-of-mixed-cases",
 			SnakeCase:  "extra_spaces_in_this_test_case_of_mixed_cases",
-		}},
+		},
+	},
 	{
 		input: "CASEBreak",
 		output: caseTests{
@@ -303,7 +336,8 @@ var allCaseTests = []struct {
 			CamelCase:  "caseBreak",
 			KebabCase:  "case-break",
 			SnakeCase:  "case_break",
-		}},
+		},
+	},
 	{
 		input: "ID",
 		output: caseTests{
@@ -311,7 +345,8 @@ var allCaseTests = []struct {
 			CamelCase:  "id",
 			KebabCase:  "id",
 			SnakeCase:  "id",
-		}},
+		},
+	},
 	{
 		input: "userID",
 		output: caseTests{
@@ -319,7 +354,8 @@ var allCaseTests = []struct {
 			CamelCase:  "userId",
 			KebabCase:  "user-id",
 			SnakeCase:  "user_id",
-		}},
+		},
+	},
 	{
 		input: "JSON_blob",
 		output: caseTests{
@@ -327,7 +363,8 @@ var allCaseTests = []struct {
 			CamelCase:  "jsonBlob",
 			KebabCase:  "json-blob",
 			SnakeCase:  "json_blob",
-		}},
+		},
+	},
 	{
 		input: "HTTPStatusCode",
 		output: caseTests{
@@ -335,7 +372,8 @@ var allCaseTests = []struct {
 			CamelCase:  "httpStatusCode",
 			KebabCase:  "http-status-code",
 			SnakeCase:  "http_status_code",
-		}},
+		},
+	},
 	{
 		input: "FreeBSD and SSLError are not golang initialisms",
 		output: caseTests{
@@ -343,7 +381,8 @@ var allCaseTests = []struct {
 			CamelCase:  "freeBsdAndSslErrorAreNotGolangInitialisms",
 			KebabCase:  "free-bsd-and-ssl-error-are-not-golang-initialisms",
 			SnakeCase:  "free_bsd_and_ssl_error_are_not_golang_initialisms",
-		}},
+		},
+	},
 	{
 		input: "David's Computer",
 		output: caseTests{
@@ -351,7 +390,8 @@ var allCaseTests = []struct {
 			CamelCase:  "davidSComputer",
 			KebabCase:  "david-s-computer",
 			SnakeCase:  "david_s_computer",
-		}},
+		},
+	},
 	{
 		input: "http200",
 		output: caseTests{
@@ -359,7 +399,8 @@ var allCaseTests = []struct {
 			CamelCase:  "http200",
 			KebabCase:  "http-200",
 			SnakeCase:  "http_200",
-		}},
+		},
+	},
 	{
 		input: "NumberSplittingVersion1.0r3",
 		output: caseTests{
@@ -367,7 +408,8 @@ var allCaseTests = []struct {
 			CamelCase:  "numberSplittingVersion10R3",
 			KebabCase:  "number-splitting-version-1-0-r3",
 			SnakeCase:  "number_splitting_version_1_0_r3",
-		}},
+		},
+	},
 	{
 		input: "When you have a comma, odd results",
 		output: caseTests{
@@ -375,7 +417,8 @@ var allCaseTests = []struct {
 			CamelCase:  "whenYouHaveACommaOddResults",
 			KebabCase:  "when-you-have-a-comma-odd-results",
 			SnakeCase:  "when_you_have_a_comma_odd_results",
-		}},
+		},
+	},
 	{
 		input: "Ordinal numbers work: 1st 2nd and 3rd place",
 		output: caseTests{
@@ -383,15 +426,17 @@ var allCaseTests = []struct {
 			CamelCase:  "ordinalNumbersWork1St2NdAnd3RdPlace",
 			KebabCase:  "ordinal-numbers-work-1-st-2-nd-and-3-rd-place",
 			SnakeCase:  "ordinal_numbers_work_1_st_2_nd_and_3_rd_place",
-		}},
+		},
+	},
 	{
 		input: "BadUTF8\xe2\xe2\xa1",
 		output: caseTests{
 			PascalCase: "BadUtf8\xe2\xe2",
 			CamelCase:  "badUtf8\xef\xbf\xbd\xef\xbf\xbd",
-			KebabCase:  "bad-utf-8\xef\xbf\xbd\xef\xbf\xbd",
-			SnakeCase:  "bad_utf_8\xef\xbf\xbd\xef\xbf\xbd",
-		}},
+			KebabCase:  "bad-utf-8\xe2\xe2",
+			SnakeCase:  "bad_utf_8\xe2\xe2",
+		},
+	},
 	{
 		input: "IDENT3",
 		output: caseTests{
@@ -399,7 +444,8 @@ var allCaseTests = []struct {
 			CamelCase:  "ident3",
 			KebabCase:  "ident-3",
 			SnakeCase:  "ident_3",
-		}},
+		},
+	},
 	{
 		input: "LogRouterS3BucketName",
 		output: caseTests{
@@ -407,7 +453,8 @@ var allCaseTests = []struct {
 			CamelCase:  "logRouterS3BucketName",
 			KebabCase:  "log-router-s3-bucket-name",
 			SnakeCase:  "log_router_s3_bucket_name",
-		}},
+		},
+	},
 	{
 		input: "PINEAPPLE",
 		output: caseTests{
@@ -415,7 +462,8 @@ var allCaseTests = []struct {
 			CamelCase:  "pineapple",
 			KebabCase:  "pineapple",
 			SnakeCase:  "pineapple",
-		}},
+		},
+	},
 	{
 		input: "Int8Value",
 		output: caseTests{
@@ -423,7 +471,8 @@ var allCaseTests = []struct {
 			CamelCase:  "int8Value",
 			KebabCase:  "int-8-value",
 			SnakeCase:  "int_8_value",
-		}},
+		},
+	},
 	{
 		input: "first.last",
 		output: caseTests{

--- a/plugins/bytes/operator_example_test.go
+++ b/plugins/bytes/operator_example_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/samber/ro"
+	"golang.org/x/text/language"
 )
 
 func ExampleCamelCase() {
@@ -86,6 +87,32 @@ func ExampleCapitalize() {
 	// Next: Hello
 	// Next: World
 	// Next: Golang
+	// Completed
+}
+
+func ExampleCapitalizeWithLanguage() {
+	observable := ro.Pipe1(
+		ro.Just([]byte("istanbul")),
+		CapitalizeWithLanguage[[]byte](language.Turkish),
+	)
+
+	subscription := observable.Subscribe(
+		ro.NewObserver(
+			func(data []byte) {
+				fmt.Printf("Next: %s\n", string(data))
+			},
+			func(err error) {
+				fmt.Printf("Error: %s\n", err.Error())
+			},
+			func() {
+				fmt.Printf("Completed\n")
+			},
+		),
+	)
+	defer subscription.Unsubscribe()
+
+	// Output:
+	// Next: İstanbul
 	// Completed
 }
 

--- a/plugins/bytes/operator_kebabcase.go
+++ b/plugins/bytes/operator_kebabcase.go
@@ -18,12 +18,26 @@ import (
 	"bytes"
 
 	"github.com/samber/ro"
+	"golang.org/x/text/language"
 )
 
 func kebabCase(str []byte) []byte {
 	items := words(str)
 	for i := range items {
-		items[i] = bytes.ToLower(items[i])
+		items[i] = lowerEnglish(items[i])
+	}
+	return bytes.Join(items, []byte("-"))
+}
+
+func kebabCaseWithLanguage(str []byte, tag language.Tag) []byte {
+	items := words(str)
+	if len(items) == 0 {
+		return []byte{}
+	}
+	pool, c := acquireLowerCaser(tag)
+	defer pool.Put(c)
+	for i := range items {
+		items[i] = c.Bytes(items[i])
 	}
 	return bytes.Join(items, []byte("-"))
 }
@@ -34,6 +48,15 @@ func KebabCase[T ~[]byte]() func(destination ro.Observable[T]) ro.Observable[T] 
 	return ro.Map(
 		func(value T) T {
 			return T(kebabCase(value))
+		},
+	)
+}
+
+// KebabCaseWithLanguage converts the byte slice to kebab case using locale-aware lowercasing.
+func KebabCaseWithLanguage[T ~[]byte](tag language.Tag) func(destination ro.Observable[T]) ro.Observable[T] {
+	return ro.Map(
+		func(value T) T {
+			return T(kebabCaseWithLanguage(value, tag))
 		},
 	)
 }

--- a/plugins/bytes/operator_kebabcase_test.go
+++ b/plugins/bytes/operator_kebabcase_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/samber/ro"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
 )
 
 func TestKebabCase(t *testing.T) {
@@ -33,7 +34,7 @@ func TestKebabCase(t *testing.T) {
 			),
 		)
 		is.Equal([]byte(t.output.KebabCase), values[0])
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -42,7 +43,7 @@ func TestKebabCase(t *testing.T) {
 			),
 		)
 		is.Equal([][]byte{}, values)
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -53,4 +54,48 @@ func TestKebabCase(t *testing.T) {
 		is.Equal([][]byte{}, values)
 		is.EqualError(err, assert.AnError.Error())
 	}
+}
+
+func TestKebabCaseWithLanguage(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	tests := []struct {
+		input []byte
+		tag   language.Tag
+		want  []byte
+	}{
+		{[]byte("HelloWorld"), language.English, []byte("hello-world")},
+		// Turkish: 'I' lowercases to 'ı' (U+0131)
+		{[]byte("IstanbulCity"), language.Turkish, []byte("ıstanbul-city")},
+	}
+
+	for _, tc := range tests {
+		values, err := ro.Collect(
+			ro.Pipe1(
+				ro.Just(tc.input),
+				KebabCaseWithLanguage[[]byte](tc.tag),
+			),
+		)
+		is.Equal(tc.want, values[0])
+		is.NoError(err)
+	}
+
+	values, err := ro.Collect(
+		ro.Pipe1(
+			ro.Empty[[]byte](),
+			KebabCaseWithLanguage[[]byte](language.English),
+		),
+	)
+	is.Equal([][]byte{}, values)
+	is.NoError(err)
+
+	values, err = ro.Collect(
+		ro.Pipe1(
+			ro.Throw[[]byte](assert.AnError),
+			KebabCaseWithLanguage[[]byte](language.English),
+		),
+	)
+	is.Equal([][]byte{}, values)
+	is.EqualError(err, assert.AnError.Error())
 }

--- a/plugins/bytes/operator_pascalcase.go
+++ b/plugins/bytes/operator_pascalcase.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 
 	"github.com/samber/ro"
+	"golang.org/x/text/language"
 )
 
 func pascalCase(str []byte) []byte {
@@ -28,12 +29,34 @@ func pascalCase(str []byte) []byte {
 	return bytes.Join(items, []byte(""))
 }
 
+func pascalCaseWithLanguage(str []byte, tag language.Tag) []byte {
+	items := words(str)
+	if len(items) == 0 {
+		return []byte{}
+	}
+	pool, c := acquireTitleCaser(tag)
+	defer pool.Put(c)
+	for i := range items {
+		items[i] = c.Bytes(items[i])
+	}
+	return bytes.Join(items, []byte(""))
+}
+
 // PascalCase converts the string to pascal case.
 // Play: https://go.dev/play/p/pBULs9BPMVD
 func PascalCase[T ~[]byte]() func(destination ro.Observable[T]) ro.Observable[T] {
 	return ro.Map(
 		func(value T) T {
 			return T(pascalCase(value))
+		},
+	)
+}
+
+// PascalCaseWithLanguage converts the byte slice to pascal case using locale-aware casing.
+func PascalCaseWithLanguage[T ~[]byte](tag language.Tag) func(destination ro.Observable[T]) ro.Observable[T] {
+	return ro.Map(
+		func(value T) T {
+			return T(pascalCaseWithLanguage(value, tag))
 		},
 	)
 }

--- a/plugins/bytes/operator_pascalcase_test.go
+++ b/plugins/bytes/operator_pascalcase_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/samber/ro"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
 )
 
 func TestPascalCase(t *testing.T) {
@@ -33,7 +34,7 @@ func TestPascalCase(t *testing.T) {
 			),
 		)
 		is.Equal([]byte(t.output.PascalCase), values[0])
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -42,7 +43,7 @@ func TestPascalCase(t *testing.T) {
 			),
 		)
 		is.Empty(values)
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -53,4 +54,48 @@ func TestPascalCase(t *testing.T) {
 		is.Empty(values)
 		is.EqualError(err, assert.AnError.Error())
 	}
+}
+
+func TestPascalCaseWithLanguage(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	tests := []struct {
+		input []byte
+		tag   language.Tag
+		want  []byte
+	}{
+		{[]byte("hello world"), language.English, []byte("HelloWorld")},
+		// Turkish: 'i' title-cases to 'İ' (U+0130)
+		{[]byte("istanbul city"), language.Turkish, []byte("İstanbulCity")},
+	}
+
+	for _, tc := range tests {
+		values, err := ro.Collect(
+			ro.Pipe1(
+				ro.Just(tc.input),
+				PascalCaseWithLanguage[[]byte](tc.tag),
+			),
+		)
+		is.Equal(tc.want, values[0])
+		is.NoError(err)
+	}
+
+	values, err := ro.Collect(
+		ro.Pipe1(
+			ro.Empty[[]byte](),
+			PascalCaseWithLanguage[[]byte](language.English),
+		),
+	)
+	is.Equal([][]byte{}, values)
+	is.NoError(err)
+
+	values, err = ro.Collect(
+		ro.Pipe1(
+			ro.Throw[[]byte](assert.AnError),
+			PascalCaseWithLanguage[[]byte](language.English),
+		),
+	)
+	is.Equal([][]byte{}, values)
+	is.EqualError(err, assert.AnError.Error())
 }

--- a/plugins/bytes/operator_snakecase.go
+++ b/plugins/bytes/operator_snakecase.go
@@ -18,12 +18,26 @@ import (
 	"bytes"
 
 	"github.com/samber/ro"
+	"golang.org/x/text/language"
 )
 
 func snakeCase(str []byte) []byte {
 	items := words(str)
 	for i := range items {
-		items[i] = bytes.ToLower(items[i])
+		items[i] = lowerEnglish(items[i])
+	}
+	return bytes.Join(items, []byte{'_'})
+}
+
+func snakeCaseWithLanguage(str []byte, tag language.Tag) []byte {
+	items := words(str)
+	if len(items) == 0 {
+		return []byte{}
+	}
+	pool, c := acquireLowerCaser(tag)
+	defer pool.Put(c)
+	for i := range items {
+		items[i] = c.Bytes(items[i])
 	}
 	return bytes.Join(items, []byte{'_'})
 }
@@ -34,6 +48,15 @@ func SnakeCase[T ~[]byte]() func(destination ro.Observable[T]) ro.Observable[T] 
 	return ro.Map(
 		func(value T) T {
 			return T(snakeCase(value))
+		},
+	)
+}
+
+// SnakeCaseWithLanguage converts the byte slice to snake case using locale-aware lowercasing.
+func SnakeCaseWithLanguage[T ~[]byte](tag language.Tag) func(destination ro.Observable[T]) ro.Observable[T] {
+	return ro.Map(
+		func(value T) T {
+			return T(snakeCaseWithLanguage(value, tag))
 		},
 	)
 }

--- a/plugins/bytes/operator_snakecase_test.go
+++ b/plugins/bytes/operator_snakecase_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/samber/ro"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
 )
 
 func TestSnakeCase(t *testing.T) {
@@ -33,7 +34,7 @@ func TestSnakeCase(t *testing.T) {
 			),
 		)
 		is.Equal([]byte(t.output.SnakeCase), values[0])
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -42,7 +43,7 @@ func TestSnakeCase(t *testing.T) {
 			),
 		)
 		is.Equal([][]byte{}, values)
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -53,4 +54,48 @@ func TestSnakeCase(t *testing.T) {
 		is.Equal([][]byte{}, values)
 		is.EqualError(err, assert.AnError.Error())
 	}
+}
+
+func TestSnakeCaseWithLanguage(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	tests := []struct {
+		input []byte
+		tag   language.Tag
+		want  []byte
+	}{
+		{[]byte("HelloWorld"), language.English, []byte("hello_world")},
+		// Turkish: 'I' lowercases to 'ı' (U+0131)
+		{[]byte("IstanbulCity"), language.Turkish, []byte("ıstanbul_city")},
+	}
+
+	for _, tc := range tests {
+		values, err := ro.Collect(
+			ro.Pipe1(
+				ro.Just(tc.input),
+				SnakeCaseWithLanguage[[]byte](tc.tag),
+			),
+		)
+		is.Equal(tc.want, values[0])
+		is.NoError(err)
+	}
+
+	values, err := ro.Collect(
+		ro.Pipe1(
+			ro.Empty[[]byte](),
+			SnakeCaseWithLanguage[[]byte](language.English),
+		),
+	)
+	is.Equal([][]byte{}, values)
+	is.NoError(err)
+
+	values, err = ro.Collect(
+		ro.Pipe1(
+			ro.Throw[[]byte](assert.AnError),
+			SnakeCaseWithLanguage[[]byte](language.English),
+		),
+	)
+	is.Equal([][]byte{}, values)
+	is.EqualError(err, assert.AnError.Error())
 }

--- a/plugins/strings/operator_camelcase.go
+++ b/plugins/strings/operator_camelcase.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/samber/ro"
+	"golang.org/x/text/language"
 )
 
 func toCamelCase(str string) string {
@@ -32,12 +33,37 @@ func toCamelCase(str string) string {
 	return strings.Join(items, "")
 }
 
+func toCamelCaseWithLanguage(str string, tag language.Tag) string {
+	items := words(str)
+	if len(items) == 0 {
+		return ""
+	}
+	lPool, lc := acquireLowerCaser(tag)
+	tPool, tc := acquireTitleCaser(tag)
+	defer lPool.Put(lc)
+	defer tPool.Put(tc)
+	items[0] = lc.String(items[0])
+	for i := 1; i < len(items); i++ {
+		items[i] = tc.String(items[i])
+	}
+	return strings.Join(items, "")
+}
+
 // CamelCase converts the string to camel case.
 // Play: https://go.dev/play/p/MMmhpwApG1y
 func CamelCase[T ~string]() func(destination ro.Observable[T]) ro.Observable[T] {
 	return ro.Map(
 		func(value T) T {
 			return T(toCamelCase(string(value)))
+		},
+	)
+}
+
+// CamelCaseWithLanguage converts the string to camel case using locale-aware casing.
+func CamelCaseWithLanguage[T ~string](tag language.Tag) func(destination ro.Observable[T]) ro.Observable[T] {
+	return ro.Map(
+		func(value T) T {
+			return T(toCamelCaseWithLanguage(string(value), tag))
 		},
 	)
 }

--- a/plugins/strings/operator_camelcase_test.go
+++ b/plugins/strings/operator_camelcase_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/samber/ro"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
 )
 
 func TestCamelCase(t *testing.T) {
@@ -33,7 +34,7 @@ func TestCamelCase(t *testing.T) {
 			),
 		)
 		is.Equal([]string{t.output.CamelCase}, values)
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -42,7 +43,7 @@ func TestCamelCase(t *testing.T) {
 			),
 		)
 		is.Equal([]string{}, values)
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -53,4 +54,48 @@ func TestCamelCase(t *testing.T) {
 		is.Equal([]string{}, values)
 		is.EqualError(err, assert.AnError.Error())
 	}
+}
+
+func TestCamelCaseWithLanguage(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	tests := []struct {
+		input string
+		tag   language.Tag
+		want  string
+	}{
+		{"hello world", language.English, "helloWorld"},
+		// Turkish: first word 'I' lowercases to 'ı' (U+0131); second word 'c' title-cases to 'C'
+		{"Istanbul city", language.Turkish, "ıstanbulCity"},
+	}
+
+	for _, tc := range tests {
+		values, err := ro.Collect(
+			ro.Pipe1(
+				ro.Just(tc.input),
+				CamelCaseWithLanguage[string](tc.tag),
+			),
+		)
+		is.Equal([]string{tc.want}, values)
+		is.NoError(err)
+	}
+
+	values, err := ro.Collect(
+		ro.Pipe1(
+			ro.Empty[string](),
+			CamelCaseWithLanguage[string](language.English),
+		),
+	)
+	is.Equal([]string{}, values)
+	is.NoError(err)
+
+	values, err = ro.Collect(
+		ro.Pipe1(
+			ro.Throw[string](assert.AnError),
+			CamelCaseWithLanguage[string](language.English),
+		),
+	)
+	is.Equal([]string{}, values)
+	is.EqualError(err, assert.AnError.Error())
 }

--- a/plugins/strings/operator_capitalize.go
+++ b/plugins/strings/operator_capitalize.go
@@ -22,19 +22,58 @@ import (
 	"golang.org/x/text/language"
 )
 
-// titleCaserPool reuses cases.Title casers: constructing one is far more
-// expensive than the casing itself, and a Caser is not safe for concurrent
-// use, so it cannot be a plain package-level singleton.
-var titleCaserPool = sync.Pool{
-	New: func() any {
-		c := cases.Title(language.English)
-		return &c
-	},
+// Dedicated English pools are cheaper than looking up the sync.Map each time.
+var (
+	englishTitleCaserPool = sync.Pool{New: func() any { c := cases.Title(language.English); return &c }}
+	englishLowerCaserPool = sync.Pool{New: func() any { c := cases.Lower(language.English); return &c }}
+
+	titleCaserPools sync.Map // map[string]*sync.Pool  (BCP 47 tag → pool of *cases.Caser)
+	lowerCaserPools sync.Map // map[string]*sync.Pool
+)
+
+func acquireTitleCaser(tag language.Tag) (*sync.Pool, *cases.Caser) {
+	key := tag.String()
+	if v, ok := titleCaserPools.Load(key); ok {
+		pool, _ := v.(*sync.Pool)
+		c, _ := pool.Get().(*cases.Caser)
+		return pool, c
+	}
+	p := &sync.Pool{New: func() any { c := cases.Title(tag); return &c }}
+	actual, _ := titleCaserPools.LoadOrStore(key, p)
+	pool, _ := actual.(*sync.Pool)
+	c, _ := pool.Get().(*cases.Caser)
+	return pool, c
+}
+
+func acquireLowerCaser(tag language.Tag) (*sync.Pool, *cases.Caser) {
+	key := tag.String()
+	if v, ok := lowerCaserPools.Load(key); ok {
+		pool, _ := v.(*sync.Pool)
+		c, _ := pool.Get().(*cases.Caser)
+		return pool, c
+	}
+	p := &sync.Pool{New: func() any { c := cases.Lower(tag); return &c }}
+	actual, _ := lowerCaserPools.LoadOrStore(key, p)
+	pool, _ := actual.(*sync.Pool)
+	c, _ := pool.Get().(*cases.Caser)
+	return pool, c
 }
 
 func capitalize(str string) string {
-	c, _ := titleCaserPool.Get().(*cases.Caser) // Pool.New always returns *cases.Caser, so the assertion never fails.
-	defer titleCaserPool.Put(c)
+	c, _ := englishTitleCaserPool.Get().(*cases.Caser)
+	defer englishTitleCaserPool.Put(c)
+	return c.String(str)
+}
+
+func lowerEnglish(str string) string {
+	c, _ := englishLowerCaserPool.Get().(*cases.Caser)
+	defer englishLowerCaserPool.Put(c)
+	return c.String(str)
+}
+
+func capitalizeWithLanguage(str string, tag language.Tag) string {
+	pool, c := acquireTitleCaser(tag)
+	defer pool.Put(c)
 	return c.String(str)
 }
 
@@ -44,6 +83,15 @@ func Capitalize[T ~string]() func(destination ro.Observable[T]) ro.Observable[T]
 	return ro.Map(
 		func(value T) T {
 			return T(capitalize(string(value)))
+		},
+	)
+}
+
+// CapitalizeWithLanguage capitalizes the first letter of the string using locale-aware casing.
+func CapitalizeWithLanguage[T ~string](tag language.Tag) func(destination ro.Observable[T]) ro.Observable[T] {
+	return ro.Map(
+		func(value T) T {
+			return T(capitalizeWithLanguage(string(value), tag))
 		},
 	)
 }

--- a/plugins/strings/operator_capitalize_test.go
+++ b/plugins/strings/operator_capitalize_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/samber/ro"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
 )
 
 func TestCapitalize(t *testing.T) {
@@ -41,7 +42,7 @@ func TestCapitalize(t *testing.T) {
 			),
 		)
 		is.Equal([]string{t.want}, values)
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -50,7 +51,7 @@ func TestCapitalize(t *testing.T) {
 			),
 		)
 		is.Equal([]string{}, values)
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -61,4 +62,49 @@ func TestCapitalize(t *testing.T) {
 		is.Equal([]string{}, values)
 		is.EqualError(err, assert.AnError.Error())
 	}
+}
+
+func TestCapitalizeWithLanguage(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	tests := []struct {
+		input string
+		tag   language.Tag
+		want  string
+	}{
+		{"hello", language.English, "Hello"},
+		{"heLLO", language.English, "Hello"},
+		// Turkish: lowercase 'i' should title-case to 'İ' (U+0130), not 'I'
+		{"istanbul", language.Turkish, "İstanbul"},
+	}
+
+	for _, tc := range tests {
+		values, err := ro.Collect(
+			ro.Pipe1(
+				ro.Just(tc.input),
+				CapitalizeWithLanguage[string](tc.tag),
+			),
+		)
+		is.Equal([]string{tc.want}, values)
+		is.NoError(err)
+	}
+
+	values, err := ro.Collect(
+		ro.Pipe1(
+			ro.Empty[string](),
+			CapitalizeWithLanguage[string](language.English),
+		),
+	)
+	is.Equal([]string{}, values)
+	is.NoError(err)
+
+	values, err = ro.Collect(
+		ro.Pipe1(
+			ro.Throw[string](assert.AnError),
+			CapitalizeWithLanguage[string](language.English),
+		),
+	)
+	is.Equal([]string{}, values)
+	is.EqualError(err, assert.AnError.Error())
 }

--- a/plugins/strings/operator_case_test.go
+++ b/plugins/strings/operator_case_test.go
@@ -39,7 +39,8 @@ var allCaseTests = []struct {
 			CamelCase:  "helloWorld",
 			KebabCase:  "hello-world",
 			SnakeCase:  "hello_world",
-		}},
+		},
+	},
 	{
 		input: "A",
 		output: caseTests{
@@ -47,7 +48,8 @@ var allCaseTests = []struct {
 			CamelCase:  "a",
 			KebabCase:  "a",
 			SnakeCase:  "a",
-		}},
+		},
+	},
 	{
 		input: "a",
 		output: caseTests{
@@ -55,7 +57,8 @@ var allCaseTests = []struct {
 			CamelCase:  "a",
 			KebabCase:  "a",
 			SnakeCase:  "a",
-		}},
+		},
+	},
 	{
 		input: "foo",
 		output: caseTests{
@@ -63,7 +66,8 @@ var allCaseTests = []struct {
 			CamelCase:  "foo",
 			KebabCase:  "foo",
 			SnakeCase:  "foo",
-		}},
+		},
+	},
 	{
 		input: "snake_case",
 		output: caseTests{
@@ -71,7 +75,8 @@ var allCaseTests = []struct {
 			CamelCase:  "snakeCase",
 			KebabCase:  "snake-case",
 			SnakeCase:  "snake_case",
-		}},
+		},
+	},
 	{
 		input: "SNAKE_CASE",
 		output: caseTests{
@@ -79,7 +84,8 @@ var allCaseTests = []struct {
 			CamelCase:  "snakeCase",
 			KebabCase:  "snake-case",
 			SnakeCase:  "snake_case",
-		}},
+		},
+	},
 	{
 		input: "kebab-case",
 		output: caseTests{
@@ -87,7 +93,8 @@ var allCaseTests = []struct {
 			CamelCase:  "kebabCase",
 			KebabCase:  "kebab-case",
 			SnakeCase:  "kebab_case",
-		}},
+		},
+	},
 	{
 		input: "PascalCase",
 		output: caseTests{
@@ -95,7 +102,8 @@ var allCaseTests = []struct {
 			CamelCase:  "pascalCase",
 			KebabCase:  "pascal-case",
 			SnakeCase:  "pascal_case",
-		}},
+		},
+	},
 	{
 		input: "camelCase",
 		output: caseTests{
@@ -103,7 +111,8 @@ var allCaseTests = []struct {
 			CamelCase:  "camelCase",
 			KebabCase:  `camel-case`,
 			SnakeCase:  "camel_case",
-		}},
+		},
+	},
 	{
 		input: "Title Case",
 		output: caseTests{
@@ -111,7 +120,8 @@ var allCaseTests = []struct {
 			CamelCase:  "titleCase",
 			KebabCase:  "title-case",
 			SnakeCase:  "title_case",
-		}},
+		},
+	},
 	{
 		input: "point.case",
 		output: caseTests{
@@ -119,7 +129,8 @@ var allCaseTests = []struct {
 			CamelCase:  "pointCase",
 			KebabCase:  "point-case",
 			SnakeCase:  "point_case",
-		}},
+		},
+	},
 	{
 		input: "snake_case_with_more_words",
 		output: caseTests{
@@ -127,7 +138,8 @@ var allCaseTests = []struct {
 			CamelCase:  "snakeCaseWithMoreWords",
 			KebabCase:  "snake-case-with-more-words",
 			SnakeCase:  "snake_case_with_more_words",
-		}},
+		},
+	},
 	{
 		input: "SNAKE_CASE_WITH_MORE_WORDS",
 		output: caseTests{
@@ -135,7 +147,8 @@ var allCaseTests = []struct {
 			CamelCase:  "snakeCaseWithMoreWords",
 			KebabCase:  "snake-case-with-more-words",
 			SnakeCase:  "snake_case_with_more_words",
-		}},
+		},
+	},
 	{
 		input: "kebab-case-with-more-words",
 		output: caseTests{
@@ -143,7 +156,8 @@ var allCaseTests = []struct {
 			CamelCase:  "kebabCaseWithMoreWords",
 			KebabCase:  "kebab-case-with-more-words",
 			SnakeCase:  "kebab_case_with_more_words",
-		}},
+		},
+	},
 	{
 		input: "PascalCaseWithMoreWords",
 		output: caseTests{
@@ -151,7 +165,8 @@ var allCaseTests = []struct {
 			CamelCase:  "pascalCaseWithMoreWords",
 			KebabCase:  "pascal-case-with-more-words",
 			SnakeCase:  "pascal_case_with_more_words",
-		}},
+		},
+	},
 	{
 		input: "camelCaseWithMoreWords",
 		output: caseTests{
@@ -159,7 +174,8 @@ var allCaseTests = []struct {
 			CamelCase:  "camelCaseWithMoreWords",
 			KebabCase:  "camel-case-with-more-words",
 			SnakeCase:  "camel_case_with_more_words",
-		}},
+		},
+	},
 	{
 		input: "Title Case With More Words",
 		output: caseTests{
@@ -167,7 +183,8 @@ var allCaseTests = []struct {
 			CamelCase:  "titleCaseWithMoreWords",
 			KebabCase:  "title-case-with-more-words",
 			SnakeCase:  "title_case_with_more_words",
-		}},
+		},
+	},
 	{
 		input: "point.case.with.more.words",
 		output: caseTests{
@@ -175,7 +192,8 @@ var allCaseTests = []struct {
 			CamelCase:  "pointCaseWithMoreWords",
 			KebabCase:  "point-case-with-more-words",
 			SnakeCase:  "point_case_with_more_words",
-		}},
+		},
+	},
 	{
 		input: "snake_case__with___multiple____delimiters",
 		output: caseTests{
@@ -183,7 +201,8 @@ var allCaseTests = []struct {
 			CamelCase:  "snakeCaseWithMultipleDelimiters",
 			KebabCase:  "snake-case-with-multiple-delimiters",
 			SnakeCase:  "snake_case_with_multiple_delimiters",
-		}},
+		},
+	},
 	{
 		input: "SNAKE_CASE__WITH___multiple____DELIMITERS",
 		output: caseTests{
@@ -191,7 +210,8 @@ var allCaseTests = []struct {
 			CamelCase:  "snakeCaseWithMultipleDelimiters",
 			KebabCase:  "snake-case-with-multiple-delimiters",
 			SnakeCase:  "snake_case_with_multiple_delimiters",
-		}},
+		},
+	},
 	{
 		input: "kebab-case--with---multiple----delimiters",
 		output: caseTests{
@@ -199,7 +219,8 @@ var allCaseTests = []struct {
 			CamelCase:  "kebabCaseWithMultipleDelimiters",
 			KebabCase:  "kebab-case-with-multiple-delimiters",
 			SnakeCase:  "kebab_case_with_multiple_delimiters",
-		}},
+		},
+	},
 	{
 		input: "Title Case  With   Multiple    Delimiters",
 		output: caseTests{
@@ -207,7 +228,8 @@ var allCaseTests = []struct {
 			CamelCase:  "titleCaseWithMultipleDelimiters",
 			KebabCase:  "title-case-with-multiple-delimiters",
 			SnakeCase:  "title_case_with_multiple_delimiters",
-		}},
+		},
+	},
 	{
 		input: "point.case..with...multiple....delimiters",
 		output: caseTests{
@@ -215,7 +237,8 @@ var allCaseTests = []struct {
 			CamelCase:  "pointCaseWithMultipleDelimiters",
 			KebabCase:  "point-case-with-multiple-delimiters",
 			SnakeCase:  "point_case_with_multiple_delimiters",
-		}},
+		},
+	},
 	{
 		input: " leading space",
 		output: caseTests{
@@ -223,7 +246,8 @@ var allCaseTests = []struct {
 			CamelCase:  "leadingSpace",
 			KebabCase:  "leading-space",
 			SnakeCase:  "leading_space",
-		}},
+		},
+	},
 	{
 		input: "   leading spaces",
 		output: caseTests{
@@ -231,7 +255,8 @@ var allCaseTests = []struct {
 			CamelCase:  "leadingSpaces",
 			KebabCase:  "leading-spaces",
 			SnakeCase:  "leading_spaces",
-		}},
+		},
+	},
 	{
 		input: "\t\t\r\n leading whitespaces",
 		output: caseTests{
@@ -239,7 +264,8 @@ var allCaseTests = []struct {
 			CamelCase:  "leadingWhitespaces",
 			KebabCase:  "leading-whitespaces",
 			SnakeCase:  "leading_whitespaces",
-		}},
+		},
+	},
 	{
 		input: "trailing space ",
 		output: caseTests{
@@ -247,7 +273,8 @@ var allCaseTests = []struct {
 			CamelCase:  "trailingSpace",
 			KebabCase:  "trailing-space",
 			SnakeCase:  "trailing_space",
-		}},
+		},
+	},
 	{
 		input: "trailing spaces   ",
 		output: caseTests{
@@ -255,7 +282,8 @@ var allCaseTests = []struct {
 			CamelCase:  "trailingSpaces",
 			KebabCase:  "trailing-spaces",
 			SnakeCase:  "trailing_spaces",
-		}},
+		},
+	},
 	{
 		input: "trailing whitespaces\t\t\r\n",
 		output: caseTests{
@@ -263,7 +291,8 @@ var allCaseTests = []struct {
 			CamelCase:  "trailingWhitespaces",
 			KebabCase:  "trailing-whitespaces",
 			SnakeCase:  "trailing_whitespaces",
-		}},
+		},
+	},
 	{
 		input: " on both sides ",
 		output: caseTests{
@@ -271,7 +300,8 @@ var allCaseTests = []struct {
 			CamelCase:  "onBothSides",
 			KebabCase:  "on-both-sides",
 			SnakeCase:  "on_both_sides",
-		}},
+		},
+	},
 	{
 		input: "    many on both sides  ",
 		output: caseTests{
@@ -279,7 +309,8 @@ var allCaseTests = []struct {
 			CamelCase:  "manyOnBothSides",
 			KebabCase:  "many-on-both-sides",
 			SnakeCase:  "many_on_both_sides",
-		}},
+		},
+	},
 	{
 		input: "\r whitespaces on both sides\t\t\r\n",
 		output: caseTests{
@@ -287,7 +318,8 @@ var allCaseTests = []struct {
 			CamelCase:  "whitespacesOnBothSides",
 			KebabCase:  "whitespaces-on-both-sides",
 			SnakeCase:  "whitespaces_on_both_sides",
-		}},
+		},
+	},
 	{
 		input: "  extraSpaces in_This TestCase Of MIXED_CASES\t",
 		output: caseTests{
@@ -295,7 +327,8 @@ var allCaseTests = []struct {
 			CamelCase:  "extraSpacesInThisTestCaseOfMixedCases",
 			KebabCase:  "extra-spaces-in-this-test-case-of-mixed-cases",
 			SnakeCase:  "extra_spaces_in_this_test_case_of_mixed_cases",
-		}},
+		},
+	},
 	{
 		input: "CASEBreak",
 		output: caseTests{
@@ -303,7 +336,8 @@ var allCaseTests = []struct {
 			CamelCase:  "caseBreak",
 			KebabCase:  "case-break",
 			SnakeCase:  "case_break",
-		}},
+		},
+	},
 	{
 		input: "ID",
 		output: caseTests{
@@ -311,7 +345,8 @@ var allCaseTests = []struct {
 			CamelCase:  "id",
 			KebabCase:  "id",
 			SnakeCase:  "id",
-		}},
+		},
+	},
 	{
 		input: "userID",
 		output: caseTests{
@@ -319,7 +354,8 @@ var allCaseTests = []struct {
 			CamelCase:  "userId",
 			KebabCase:  "user-id",
 			SnakeCase:  "user_id",
-		}},
+		},
+	},
 	{
 		input: "JSON_blob",
 		output: caseTests{
@@ -327,7 +363,8 @@ var allCaseTests = []struct {
 			CamelCase:  "jsonBlob",
 			KebabCase:  "json-blob",
 			SnakeCase:  "json_blob",
-		}},
+		},
+	},
 	{
 		input: "HTTPStatusCode",
 		output: caseTests{
@@ -335,7 +372,8 @@ var allCaseTests = []struct {
 			CamelCase:  "httpStatusCode",
 			KebabCase:  "http-status-code",
 			SnakeCase:  "http_status_code",
-		}},
+		},
+	},
 	{
 		input: "FreeBSD and SSLError are not golang initialisms",
 		output: caseTests{
@@ -343,7 +381,8 @@ var allCaseTests = []struct {
 			CamelCase:  "freeBsdAndSslErrorAreNotGolangInitialisms",
 			KebabCase:  "free-bsd-and-ssl-error-are-not-golang-initialisms",
 			SnakeCase:  "free_bsd_and_ssl_error_are_not_golang_initialisms",
-		}},
+		},
+	},
 	{
 		input: "David's Computer",
 		output: caseTests{
@@ -351,7 +390,8 @@ var allCaseTests = []struct {
 			CamelCase:  "davidSComputer",
 			KebabCase:  "david-s-computer",
 			SnakeCase:  "david_s_computer",
-		}},
+		},
+	},
 	{
 		input: "http200",
 		output: caseTests{
@@ -359,7 +399,8 @@ var allCaseTests = []struct {
 			CamelCase:  "http200",
 			KebabCase:  "http-200",
 			SnakeCase:  "http_200",
-		}},
+		},
+	},
 	{
 		input: "NumberSplittingVersion1.0r3",
 		output: caseTests{
@@ -367,7 +408,8 @@ var allCaseTests = []struct {
 			CamelCase:  "numberSplittingVersion10R3",
 			KebabCase:  "number-splitting-version-1-0-r3",
 			SnakeCase:  "number_splitting_version_1_0_r3",
-		}},
+		},
+	},
 	{
 		input: "When you have a comma, odd results",
 		output: caseTests{
@@ -375,7 +417,8 @@ var allCaseTests = []struct {
 			CamelCase:  "whenYouHaveACommaOddResults",
 			KebabCase:  "when-you-have-a-comma-odd-results",
 			SnakeCase:  "when_you_have_a_comma_odd_results",
-		}},
+		},
+	},
 	{
 		input: "Ordinal numbers work: 1st 2nd and 3rd place",
 		output: caseTests{
@@ -383,7 +426,8 @@ var allCaseTests = []struct {
 			CamelCase:  "ordinalNumbersWork1St2NdAnd3RdPlace",
 			KebabCase:  "ordinal-numbers-work-1-st-2-nd-and-3-rd-place",
 			SnakeCase:  "ordinal_numbers_work_1_st_2_nd_and_3_rd_place",
-		}},
+		},
+	},
 	{
 		input: "BadUTF8\xe2\xe2\xa1",
 		output: caseTests{
@@ -391,7 +435,8 @@ var allCaseTests = []struct {
 			CamelCase:  "badUtf8",
 			KebabCase:  "bad-utf-8",
 			SnakeCase:  "bad_utf_8",
-		}},
+		},
+	},
 	{
 		input: "IDENT3",
 		output: caseTests{
@@ -399,7 +444,8 @@ var allCaseTests = []struct {
 			CamelCase:  "ident3",
 			KebabCase:  "ident-3",
 			SnakeCase:  "ident_3",
-		}},
+		},
+	},
 	{
 		input: "LogRouterS3BucketName",
 		output: caseTests{
@@ -407,7 +453,8 @@ var allCaseTests = []struct {
 			CamelCase:  "logRouterS3BucketName",
 			KebabCase:  "log-router-s3-bucket-name",
 			SnakeCase:  "log_router_s3_bucket_name",
-		}},
+		},
+	},
 	{
 		input: "PINEAPPLE",
 		output: caseTests{
@@ -415,7 +462,8 @@ var allCaseTests = []struct {
 			CamelCase:  "pineapple",
 			KebabCase:  "pineapple",
 			SnakeCase:  "pineapple",
-		}},
+		},
+	},
 	{
 		input: "Int8Value",
 		output: caseTests{
@@ -423,7 +471,8 @@ var allCaseTests = []struct {
 			CamelCase:  "int8Value",
 			KebabCase:  "int-8-value",
 			SnakeCase:  "int_8_value",
-		}},
+		},
+	},
 	{
 		input: "first.last",
 		output: caseTests{

--- a/plugins/strings/operator_example_test.go
+++ b/plugins/strings/operator_example_test.go
@@ -16,6 +16,7 @@ package rostrings
 
 import (
 	"github.com/samber/ro"
+	"golang.org/x/text/language"
 )
 
 func ExampleCamelCase() {
@@ -59,6 +60,20 @@ func ExampleCapitalize() {
 	// Next: Hello
 	// Next: World
 	// Next: Golang
+	// Completed
+}
+
+func ExampleCapitalizeWithLanguage() {
+	obs := ro.Pipe[string, string](
+		ro.Just("istanbul"),
+		CapitalizeWithLanguage[string](language.Turkish),
+	)
+
+	sub := obs.Subscribe(ro.PrintObserver[string]())
+	defer sub.Unsubscribe()
+
+	// Output:
+	// Next: İstanbul
 	// Completed
 }
 

--- a/plugins/strings/operator_kebabcase.go
+++ b/plugins/strings/operator_kebabcase.go
@@ -18,12 +18,26 @@ import (
 	"strings"
 
 	"github.com/samber/ro"
+	"golang.org/x/text/language"
 )
 
 func kebabCase(str string) string {
 	items := words(str)
 	for i := range items {
-		items[i] = strings.ToLower(items[i])
+		items[i] = lowerEnglish(items[i])
+	}
+	return strings.Join(items, "-")
+}
+
+func kebabCaseWithLanguage(str string, tag language.Tag) string {
+	items := words(str)
+	if len(items) == 0 {
+		return ""
+	}
+	pool, c := acquireLowerCaser(tag)
+	defer pool.Put(c)
+	for i := range items {
+		items[i] = c.String(items[i])
 	}
 	return strings.Join(items, "-")
 }
@@ -34,6 +48,15 @@ func KebabCase[T ~string]() func(destination ro.Observable[T]) ro.Observable[T] 
 	return ro.Map(
 		func(value T) T {
 			return T(kebabCase(string(value)))
+		},
+	)
+}
+
+// KebabCaseWithLanguage converts the string to kebab case using locale-aware lowercasing.
+func KebabCaseWithLanguage[T ~string](tag language.Tag) func(destination ro.Observable[T]) ro.Observable[T] {
+	return ro.Map(
+		func(value T) T {
+			return T(kebabCaseWithLanguage(string(value), tag))
 		},
 	)
 }

--- a/plugins/strings/operator_kebabcase_test.go
+++ b/plugins/strings/operator_kebabcase_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/samber/ro"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
 )
 
 func TestKebabCase(t *testing.T) {
@@ -33,7 +34,7 @@ func TestKebabCase(t *testing.T) {
 			),
 		)
 		is.Equal([]string{t.output.KebabCase}, values)
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -42,7 +43,7 @@ func TestKebabCase(t *testing.T) {
 			),
 		)
 		is.Equal([]string{}, values)
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -53,4 +54,48 @@ func TestKebabCase(t *testing.T) {
 		is.Equal([]string{}, values)
 		is.EqualError(err, assert.AnError.Error())
 	}
+}
+
+func TestKebabCaseWithLanguage(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	tests := []struct {
+		input string
+		tag   language.Tag
+		want  string
+	}{
+		{"HelloWorld", language.English, "hello-world"},
+		// Turkish: 'I' should lowercase to 'ı' (U+0131), not 'i'
+		{"IstanbulCity", language.Turkish, "ıstanbul-city"},
+	}
+
+	for _, tc := range tests {
+		values, err := ro.Collect(
+			ro.Pipe1(
+				ro.Just(tc.input),
+				KebabCaseWithLanguage[string](tc.tag),
+			),
+		)
+		is.Equal([]string{tc.want}, values)
+		is.NoError(err)
+	}
+
+	values, err := ro.Collect(
+		ro.Pipe1(
+			ro.Empty[string](),
+			KebabCaseWithLanguage[string](language.English),
+		),
+	)
+	is.Equal([]string{}, values)
+	is.NoError(err)
+
+	values, err = ro.Collect(
+		ro.Pipe1(
+			ro.Throw[string](assert.AnError),
+			KebabCaseWithLanguage[string](language.English),
+		),
+	)
+	is.Equal([]string{}, values)
+	is.EqualError(err, assert.AnError.Error())
 }

--- a/plugins/strings/operator_pascalcase.go
+++ b/plugins/strings/operator_pascalcase.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/samber/ro"
+	"golang.org/x/text/language"
 )
 
 func pascalCase(str string) string {
@@ -28,12 +29,34 @@ func pascalCase(str string) string {
 	return strings.Join(items, "")
 }
 
+func pascalCaseWithLanguage(str string, tag language.Tag) string {
+	items := words(str)
+	if len(items) == 0 {
+		return ""
+	}
+	pool, c := acquireTitleCaser(tag)
+	defer pool.Put(c)
+	for i := range items {
+		items[i] = c.String(items[i])
+	}
+	return strings.Join(items, "")
+}
+
 // PascalCase converts the string to pascal case.
 // Play: https://go.dev/play/p/107SvPGvHAK
 func PascalCase[T ~string]() func(destination ro.Observable[T]) ro.Observable[T] {
 	return ro.Map(
 		func(value T) T {
 			return T(pascalCase(string(value)))
+		},
+	)
+}
+
+// PascalCaseWithLanguage converts the string to pascal case using locale-aware casing.
+func PascalCaseWithLanguage[T ~string](tag language.Tag) func(destination ro.Observable[T]) ro.Observable[T] {
+	return ro.Map(
+		func(value T) T {
+			return T(pascalCaseWithLanguage(string(value), tag))
 		},
 	)
 }

--- a/plugins/strings/operator_pascalcase_test.go
+++ b/plugins/strings/operator_pascalcase_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/samber/ro"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
 )
 
 func TestPascalCase(t *testing.T) {
@@ -33,7 +34,7 @@ func TestPascalCase(t *testing.T) {
 			),
 		)
 		is.Equal([]string{t.output.PascalCase}, values)
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -42,7 +43,7 @@ func TestPascalCase(t *testing.T) {
 			),
 		)
 		is.Equal([]string{}, values)
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -53,4 +54,48 @@ func TestPascalCase(t *testing.T) {
 		is.Equal([]string{}, values)
 		is.EqualError(err, assert.AnError.Error())
 	}
+}
+
+func TestPascalCaseWithLanguage(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	tests := []struct {
+		input string
+		tag   language.Tag
+		want  string
+	}{
+		{"hello world", language.English, "HelloWorld"},
+		// Turkish: 'i' title-cases to 'İ' (U+0130)
+		{"istanbul city", language.Turkish, "İstanbulCity"},
+	}
+
+	for _, tc := range tests {
+		values, err := ro.Collect(
+			ro.Pipe1(
+				ro.Just(tc.input),
+				PascalCaseWithLanguage[string](tc.tag),
+			),
+		)
+		is.Equal([]string{tc.want}, values)
+		is.NoError(err)
+	}
+
+	values, err := ro.Collect(
+		ro.Pipe1(
+			ro.Empty[string](),
+			PascalCaseWithLanguage[string](language.English),
+		),
+	)
+	is.Equal([]string{}, values)
+	is.NoError(err)
+
+	values, err = ro.Collect(
+		ro.Pipe1(
+			ro.Throw[string](assert.AnError),
+			PascalCaseWithLanguage[string](language.English),
+		),
+	)
+	is.Equal([]string{}, values)
+	is.EqualError(err, assert.AnError.Error())
 }

--- a/plugins/strings/operator_snakecase.go
+++ b/plugins/strings/operator_snakecase.go
@@ -18,12 +18,26 @@ import (
 	"strings"
 
 	"github.com/samber/ro"
+	"golang.org/x/text/language"
 )
 
 func snakeCase(str string) string {
 	items := words(str)
 	for i := range items {
-		items[i] = strings.ToLower(items[i])
+		items[i] = lowerEnglish(items[i])
+	}
+	return strings.Join(items, "_")
+}
+
+func snakeCaseWithLanguage(str string, tag language.Tag) string {
+	items := words(str)
+	if len(items) == 0 {
+		return ""
+	}
+	pool, c := acquireLowerCaser(tag)
+	defer pool.Put(c)
+	for i := range items {
+		items[i] = c.String(items[i])
 	}
 	return strings.Join(items, "_")
 }
@@ -34,6 +48,15 @@ func SnakeCase[T ~string]() func(destination ro.Observable[T]) ro.Observable[T] 
 	return ro.Map(
 		func(value T) T {
 			return T(snakeCase(string(value)))
+		},
+	)
+}
+
+// SnakeCaseWithLanguage converts the string to snake case using locale-aware lowercasing.
+func SnakeCaseWithLanguage[T ~string](tag language.Tag) func(destination ro.Observable[T]) ro.Observable[T] {
+	return ro.Map(
+		func(value T) T {
+			return T(snakeCaseWithLanguage(string(value), tag))
 		},
 	)
 }

--- a/plugins/strings/operator_snakecase_test.go
+++ b/plugins/strings/operator_snakecase_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/samber/ro"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
 )
 
 func TestSnakeCase(t *testing.T) {
@@ -33,7 +34,7 @@ func TestSnakeCase(t *testing.T) {
 			),
 		)
 		is.Equal([]string{t.output.SnakeCase}, values)
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -42,7 +43,7 @@ func TestSnakeCase(t *testing.T) {
 			),
 		)
 		is.Equal([]string{}, values)
-		is.Nil(err)
+		is.NoError(err)
 
 		values, err = ro.Collect(
 			ro.Pipe1(
@@ -53,4 +54,48 @@ func TestSnakeCase(t *testing.T) {
 		is.Equal([]string{}, values)
 		is.EqualError(err, assert.AnError.Error())
 	}
+}
+
+func TestSnakeCaseWithLanguage(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	tests := []struct {
+		input string
+		tag   language.Tag
+		want  string
+	}{
+		{"HelloWorld", language.English, "hello_world"},
+		// Turkish: 'I' should lowercase to 'ı' (U+0131), not 'i'
+		{"IstanbulCity", language.Turkish, "ıstanbul_city"},
+	}
+
+	for _, tc := range tests {
+		values, err := ro.Collect(
+			ro.Pipe1(
+				ro.Just(tc.input),
+				SnakeCaseWithLanguage[string](tc.tag),
+			),
+		)
+		is.Equal([]string{tc.want}, values)
+		is.NoError(err)
+	}
+
+	values, err := ro.Collect(
+		ro.Pipe1(
+			ro.Empty[string](),
+			SnakeCaseWithLanguage[string](language.English),
+		),
+	)
+	is.Equal([]string{}, values)
+	is.NoError(err)
+
+	values, err = ro.Collect(
+		ro.Pipe1(
+			ro.Throw[string](assert.AnError),
+			SnakeCaseWithLanguage[string](language.English),
+		),
+	)
+	is.Equal([]string{}, values)
+	is.EqualError(err, assert.AnError.Error())
 }


### PR DESCRIPTION
## Summary

Port of [samber/lo#916](https://github.com/samber/lo/pull/916) to the reactive streaming equivalents in `samber/ro`.

- Adds `CapitalizeWithLanguage`, `PascalCaseWithLanguage`, `CamelCaseWithLanguage`, `SnakeCaseWithLanguage`, and `KebabCaseWithLanguage` operators to both the `strings` and `bytes` plugins
- Uses `golang.org/x/text/language.Tag` (BCP 47) for locale-aware casing (e.g. Turkish: `i`→`İ`, `I`→`ı`)
- Two-tier `sync.Pool` strategy: dedicated English pools (fast path) + lazy per-tag pools via `sync.Map`
- Switches base `SnakeCase`/`KebabCase` from `strings/bytes.ToLower` to `cases.Lower(language.English)` for locale-correct lowercasing, consistent with lo#916
- Creates missing `docs/data/plugin-strings-pascalcase.md` documentation file
- Updates all existing operator docs with the new `WithLanguage` signatures and examples
- Adds `TestXxxWithLanguage` tests covering Turkish locale and edge cases (empty source, error source)