### PR TITLE
fix(plugins/strings,bytes): sync fixes from samber/lo

### DIFF
--- a/plugins/bytes/operator_ellipsis.go
+++ b/plugins/bytes/operator_ellipsis.go
@@ -16,6 +16,7 @@ package robytes
 
 import (
 	"bytes"
+	"unicode/utf8"
 
 	"github.com/samber/ro"
 )
@@ -23,11 +24,19 @@ import (
 func ellipsis(str []byte, length int) []byte {
 	str = bytes.TrimSpace(str)
 
-	if len(str) > length {
-		if len(str) < 3 || length < 3 {
-			return []byte("...")
+	const ell = "..."
+
+	cutPosition := 0
+	i := 0
+	for i < len(str) {
+		if length == len(ell) {
+			cutPosition = i
 		}
-		return append(bytes.TrimSpace(str[0:length-3]), '.', '.', '.')
+		if length--; length < 0 {
+			return append(bytes.TrimSpace(str[:cutPosition:cutPosition]), '.', '.', '.')
+		}
+		_, size := utf8.DecodeRune(str[i:])
+		i += size
 	}
 
 	return str

--- a/plugins/bytes/operator_ellipsis_test.go
+++ b/plugins/bytes/operator_ellipsis_test.go
@@ -40,6 +40,16 @@ func TestEllipsis(t *testing.T) {
 		{"12345", 2, "..."},
 		{"12345", -1, "..."},
 		{" hello   world ", 9, "hello..."},
+		// Unicode: rune-based truncation (not byte-based)
+		{"hello 世界! 你好", 8, "hello..."},
+		{"hello 世界! 你好", 11, "hello 世界..."},
+		{"hello 世界! 你好", 12, "hello 世界! 你好"},
+		{"🏠🐶🐱🌟", 5, "🏠🐶🐱🌟"},
+		{"🏠🐶🐱🌟", 4, "🏠🐶🐱🌟"},
+		{"🏠🐶🐱🌟", 3, "..."},
+		{"🏠🐶🐱🌟🎉🌈", 5, "🏠🐶..."},
+		{"café", 4, "café"},
+		{"café au lait", 5, "ca..."},
 	}
 
 	for _, t := range tests {

--- a/plugins/bytes/operator_random.go
+++ b/plugins/bytes/operator_random.go
@@ -53,8 +53,17 @@ func nearestPowerOfTwo(cap int) int {
 
 func random(size int, charset []rune) []byte {
 	// see https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-go
-	sb := bytes.Buffer{}
+	var sb bytes.Buffer
 	sb.Grow(size)
+
+	// Edge case: single-character charset would cause letterIdBits=0 (division by zero below).
+	if len(charset) == 1 {
+		for i := 0; i < size; i++ {
+			sb.WriteRune(charset[0])
+		}
+		return sb.Bytes()
+	}
+
 	// Calculate the number of bits required to represent the charset,
 	// e.g., for 62 characters, it would need 6 bits (since 62 -> 64 = 2^6)
 	letterIdBits := int(math.Log2(float64(nearestPowerOfTwo(len(charset)))))
@@ -88,10 +97,10 @@ func random(size int, charset []rune) []byte {
 // Play: https://go.dev/play/p/hX7F8StRq6Q
 func Random[T any](size int, charset []rune) func(destination ro.Observable[T]) ro.Observable[[]byte] {
 	if size <= 0 {
-		panic("robytes.Random: Size parameter must be greater than 0")
+		panic("robytes.Random: size must be greater than 0")
 	}
 	if len(charset) <= 0 {
-		panic("robytes.Random: Charset parameter must not be empty")
+		panic("robytes.Random: charset must not be empty")
 	}
 
 	return ro.Map(

--- a/plugins/bytes/operator_random_test.go
+++ b/plugins/bytes/operator_random_test.go
@@ -61,14 +61,25 @@ func TestRandom(t *testing.T) {
 	is.Subset([]byte("明1好休2林森"), values[0])
 	is.Nil(err)
 
+	// Single-char charset: must not divide by zero
+	values3, err := ro.Collect(
+		ro.Pipe1(
+			ro.Just(struct{}{}),
+			Random[struct{}](10, []rune{65}),
+		),
+	)
+	is.Equal(10, utf8.RuneCount(values3[0]))
+	is.Equal([]byte("AAAAAAAAAA"), values3[0])
+	is.Nil(err)
+
 	is.PanicsWithValue(
-		"robytes.Random: Charset parameter must not be empty",
+		"robytes.Random: charset must not be empty",
 		func() {
 			_ = Random[struct{}](100, []rune{})
 		},
 	)
 	is.PanicsWithValue(
-		"robytes.Random: Size parameter must be greater than 0",
+		"robytes.Random: size must be greater than 0",
 		func() {
 			_ = Random[struct{}](0, LowerCaseLettersCharset)
 		},

--- a/plugins/bytes/operator_words.go
+++ b/plugins/bytes/operator_words.go
@@ -26,6 +26,7 @@ func words(str []byte) [][]byte {
 	// example: Int8Value => Int 8Value => Int 8 Value
 	str = splitNumberLetterReg.ReplaceAll(str, []byte("$1 $2"))
 	var result bytes.Buffer
+	result.Grow(len(str))
 	for _, r := range str {
 		if unicode.IsLetter(rune(r)) || unicode.IsDigit(rune(r)) {
 			result.WriteByte(r)

--- a/plugins/strings/operator_ellipsis.go
+++ b/plugins/strings/operator_ellipsis.go
@@ -23,11 +23,16 @@ import (
 func ellipsis(str string, length int) string {
 	str = strings.TrimSpace(str)
 
-	if len(str) > length {
-		if len(str) < 3 || length < 3 {
-			return "..."
+	const ellipsis = "..."
+
+	cutPosition := 0
+	for i := range str {
+		if length == len(ellipsis) {
+			cutPosition = i
 		}
-		return strings.TrimSpace(str[0:length-3]) + "..."
+		if length--; length < 0 {
+			return strings.TrimSpace(str[:cutPosition]) + ellipsis
+		}
 	}
 
 	return str

--- a/plugins/strings/operator_ellipsis_test.go
+++ b/plugins/strings/operator_ellipsis_test.go
@@ -40,6 +40,16 @@ func TestEllipsis(t *testing.T) {
 		{"12345", 2, "..."},
 		{"12345", -1, "..."},
 		{" hello   world ", 9, "hello..."},
+		// Unicode: rune-based truncation (not byte-based)
+		{"hello 世界! 你好", 8, "hello..."},
+		{"hello 世界! 你好", 11, "hello 世界..."},
+		{"hello 世界! 你好", 12, "hello 世界! 你好"},
+		{"🏠🐶🐱🌟", 5, "🏠🐶🐱🌟"},
+		{"🏠🐶🐱🌟", 4, "🏠🐶🐱🌟"},
+		{"🏠🐶🐱🌟", 3, "..."},
+		{"🏠🐶🐱🌟🎉🌈", 5, "🏠🐶..."},
+		{"café", 4, "café"},
+		{"café au lait", 5, "ca..."},
 	}
 
 	for _, t := range tests {

--- a/plugins/strings/operator_random.go
+++ b/plugins/strings/operator_random.go
@@ -53,8 +53,17 @@ func nearestPowerOfTwo(cap int) int {
 
 func random(size int, charset []rune) string {
 	// see https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-go
-	sb := strings.Builder{}
+	var sb strings.Builder
 	sb.Grow(size)
+
+	// Edge case: single-character charset would cause letterIdBits=0 (division by zero below).
+	if len(charset) == 1 {
+		for i := 0; i < size; i++ {
+			sb.WriteRune(charset[0])
+		}
+		return sb.String()
+	}
+
 	// Calculate the number of bits required to represent the charset,
 	// e.g., for 62 characters, it would need 6 bits (since 62 -> 64 = 2^6)
 	letterIdBits := int(math.Log2(float64(nearestPowerOfTwo(len(charset)))))
@@ -88,10 +97,10 @@ func random(size int, charset []rune) string {
 // Play: https://go.dev/play/p/7oDIGRxvrGt
 func Random[T any](size int, charset []rune) func(destination ro.Observable[T]) ro.Observable[string] {
 	if size <= 0 {
-		panic("rostrings.Random: Size parameter must be greater than 0")
+		panic("rostrings.Random: size must be greater than 0")
 	}
 	if len(charset) <= 0 {
-		panic("rostrings.Random: Charset parameter must not be empty")
+		panic("rostrings.Random: charset must not be empty")
 	}
 
 	return ro.Map(

--- a/plugins/strings/operator_random_test.go
+++ b/plugins/strings/operator_random_test.go
@@ -61,14 +61,25 @@ func TestRandom(t *testing.T) {
 	is.Subset([]rune("明1好休2林森"), []rune(values[0]))
 	is.Nil(err)
 
+	// Single-char charset: must not divide by zero
+	values3, err := ro.Collect(
+		ro.Pipe1(
+			ro.Just(struct{}{}),
+			Random[struct{}](10, []rune{65}),
+		),
+	)
+	is.Equal(10, utf8.RuneCountInString(values3[0]))
+	is.Equal("AAAAAAAAAA", values3[0])
+	is.Nil(err)
+
 	is.PanicsWithValue(
-		"rostrings.Random: Charset parameter must not be empty",
+		"rostrings.Random: charset must not be empty",
 		func() {
 			_ = Random[struct{}](100, []rune{})
 		},
 	)
 	is.PanicsWithValue(
-		"rostrings.Random: Size parameter must be greater than 0",
+		"rostrings.Random: size must be greater than 0",
 		func() {
 			_ = Random[struct{}](0, LowerCaseLettersCharset)
 		},

--- a/plugins/strings/operator_words.go
+++ b/plugins/strings/operator_words.go
@@ -26,6 +26,7 @@ func words(str string) []string {
 	// example: Int8Value => Int 8Value => Int 8 Value
 	str = splitNumberLetterReg.ReplaceAllString(str, "$1 $2")
 	var result strings.Builder
+	result.Grow(len(str))
 	for _, r := range str {
 		if unicode.IsLetter(r) || unicode.IsDigit(r) {
 			result.WriteRune(r)


### PR DESCRIPTION
## Summary

Backport of 4 fixes from [`samber/lo`](https://github.com/samber/lo) that apply to the `plugins/strings` and `plugins/bytes` packages, which share the same string-handling logic.

### Bug fixes

- **`Ellipsis` — rune-aware truncation** ([lo#796](https://github.com/samber/lo/commit/0b4623da1e71d19237c519b79f1852ec7b707961)): the previous implementation used byte-based length counting (`len(str)`) and byte-based slicing, which could split multi-byte Unicode characters (emoji, CJK, accented chars) in the middle. The new implementation iterates over runes so the `length` parameter counts Unicode code points.

- **`Random` — division by zero with single-character charset** ([lo#684](https://github.com/samber/lo/commit/b5e290abe0ae627800f3612ca98b1e942d711562)): when `len(charset) == 1`, `math.Log2(1) == 0`, which caused `letterIdMax = 63 / letterIdBits` to panic. Added an early-return fast path for this case.

### Other improvements

- **`Random` — normalize panic messages to lowercase** ([lo#678](https://github.com/samber/lo/commit/268215359e7eec34a8c0d34476472240c8a9284f)): `"Size parameter must be greater than 0"` → `"size must be greater than 0"`, consistent with lo conventions.

- **`Words` — preallocate string buffer** ([lo#728](https://github.com/samber/lo/commit/4e2c33e8a4b6067228ad70fa8e1d00b248ed97bc)): add `result.Grow(len(str))` to avoid repeated reallocations when building the word-split buffer.

## Commits not applied

- `68f827d` — `Substring` optimization: no `Substring` operator in these plugins
- `123d5c2` — `ChunkString` redundant check: no `ChunkString` in these plugins
- `18c5a43` — `rand` → `xrand` rename: already done in `samber/ro`