### PR TITLE
fix(plugins): use sentinel error variables instead of panic with strings

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -181,6 +181,41 @@ Create a [Go Playground](https://go.dev/play/) demonstration for each operator, 
 
 Please add an example of your operator in the file named `ro_example_test.go`. It will be visible in Godoc website: https://pkg.go.dev/github.com/samber/ro
 
+## Error conventions
+
+Errors must be declared as package-level sentinel variables using `errors.New`, never as inline strings or `fmt.Errorf` calls in a `panic`.
+
+Each package (core or plugin) that panics on invalid input **must** declare its errors in a dedicated `errors.go` file:
+
+```go
+// errors.go
+package myplugin
+
+import "errors"
+
+var (
+    ErrMyOperatorWrongParam = errors.New("myplugin.MyOperator: param must be greater than 0")
+)
+```
+
+Then use the variable in the operator:
+
+```go
+func MyOperator(param int) func(ro.Observable[T]) ro.Observable[T] {
+    if param <= 0 {
+        panic(ErrMyOperatorWrongParam)
+    }
+    // ...
+}
+```
+
+**Rules:**
+- Use `errors.New` — never `fmt.Errorf` or a bare string — for sentinel error declarations.
+- Error variable names follow the pattern `Err{OperatorName}{WhatIsWrong}` (e.g., `ErrRandomWrongSize`, `ErrWebsocketSubjectURLRequired`).
+- Error messages follow the pattern `{package}.{FunctionName}: {lowercase description}` (e.g., `"rostrings.Random: size must be greater than 0"`).
+- Never write `panic("some string")` or `panic(errors.New("..."))` inline — always use a pre-declared variable.
+- Panics are reserved for programmer errors detected at construction time (invalid parameters), never for runtime stream errors.
+
 ## Other conventions
 
 ### Naming

--- a/plugins/bytes/errors.go
+++ b/plugins/bytes/errors.go
@@ -1,0 +1,22 @@
+// Copyright 2025 samber.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/samber/ro/blob/main/licenses/LICENSE.apache.md
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package robytes
+
+import "errors"
+
+var (
+	ErrRandomWrongSize    = errors.New("robytes.Random: size must be greater than 0")
+	ErrRandomEmptyCharset = errors.New("robytes.Random: charset must not be empty")
+)

--- a/plugins/bytes/operator_random.go
+++ b/plugins/bytes/operator_random.go
@@ -97,10 +97,10 @@ func random(size int, charset []rune) []byte {
 // Play: https://go.dev/play/p/hX7F8StRq6Q
 func Random[T any](size int, charset []rune) func(destination ro.Observable[T]) ro.Observable[[]byte] {
 	if size <= 0 {
-		panic("robytes.Random: size must be greater than 0")
+		panic(ErrRandomWrongSize)
 	}
 	if len(charset) <= 0 {
-		panic("robytes.Random: charset must not be empty")
+		panic(ErrRandomEmptyCharset)
 	}
 
 	return ro.Map(

--- a/plugins/bytes/operator_random_test.go
+++ b/plugins/bytes/operator_random_test.go
@@ -72,13 +72,13 @@ func TestRandom(t *testing.T) {
 	is.Equal([]byte("AAAAAAAAAA"), values3[0])
 	is.Nil(err)
 
-	is.PanicsWithValue(
+	is.PanicsWithError(
 		"robytes.Random: charset must not be empty",
 		func() {
 			_ = Random[struct{}](100, []rune{})
 		},
 	)
-	is.PanicsWithValue(
+	is.PanicsWithError(
 		"robytes.Random: size must be greater than 0",
 		func() {
 			_ = Random[struct{}](0, LowerCaseLettersCharset)

--- a/plugins/hyperloglog/errors.go
+++ b/plugins/hyperloglog/errors.go
@@ -1,0 +1,21 @@
+// Copyright 2025 samber.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/samber/ro/blob/main/licenses/LICENSE.apache.md
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rohyperloglog
+
+import "errors"
+
+var (
+	ErrInvalidPrecision = errors.New("rohyperloglog.CountDistinct: precision has to be >= 4 and <= 18")
+)

--- a/plugins/hyperloglog/go.mod
+++ b/plugins/hyperloglog/go.mod
@@ -10,7 +10,7 @@ require (
 require (
 	github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33 // indirect
 	github.com/kamstrup/intmap v0.5.2 // indirect
-	github.com/samber/lo v1.52.0 // indirect
+	github.com/samber/lo v1.53.0 // indirect
 	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8 // indirect
 	golang.org/x/text v0.22.0 // indirect
 )

--- a/plugins/hyperloglog/go.sum
+++ b/plugins/hyperloglog/go.sum
@@ -8,8 +8,8 @@ github.com/kamstrup/intmap v0.5.2 h1:qnwBm1mh4XAnW9W9Ue9tZtTff8pS6+s6iKF6JRIV2Dk
 github.com/kamstrup/intmap v0.5.2/go.mod h1:gWUVWHKzWj8xpJVFf5GC0O26bWmv3GqdnIX/LMT6Aq4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/samber/lo v1.52.0 h1:Rvi+3BFHES3A8meP33VPAxiBZX/Aws5RxrschYGjomw=
-github.com/samber/lo v1.52.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
+github.com/samber/lo v1.53.0 h1:t975lj2py4kJPQ6haz1QMgtId2gtmfktACxIXArw3HM=
+github.com/samber/lo v1.53.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=

--- a/plugins/hyperloglog/operator.go
+++ b/plugins/hyperloglog/operator.go
@@ -17,13 +17,10 @@ package rohyperloglog
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/axiomhq/hyperloglog"
 	"github.com/samber/ro"
 )
-
-var ErrInvalidPrecision = fmt.Errorf("rohyperloglog.CountDistinct: precision has to be >= 4 and <= 18")
 
 func CountDistinct[T comparable](precision uint8, sparse bool, hashFunc func(input T) uint64) func(ro.Observable[T]) ro.Observable[uint64] {
 	if precision < 4 || precision > 18 {

--- a/plugins/strings/errors.go
+++ b/plugins/strings/errors.go
@@ -1,0 +1,22 @@
+// Copyright 2025 samber.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/samber/ro/blob/main/licenses/LICENSE.apache.md
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rostrings
+
+import "errors"
+
+var (
+	ErrRandomWrongSize    = errors.New("rostrings.Random: size must be greater than 0")
+	ErrRandomEmptyCharset = errors.New("rostrings.Random: charset must not be empty")
+)

--- a/plugins/strings/operator_random.go
+++ b/plugins/strings/operator_random.go
@@ -97,10 +97,10 @@ func random(size int, charset []rune) string {
 // Play: https://go.dev/play/p/7oDIGRxvrGt
 func Random[T any](size int, charset []rune) func(destination ro.Observable[T]) ro.Observable[string] {
 	if size <= 0 {
-		panic("rostrings.Random: size must be greater than 0")
+		panic(ErrRandomWrongSize)
 	}
 	if len(charset) <= 0 {
-		panic("rostrings.Random: charset must not be empty")
+		panic(ErrRandomEmptyCharset)
 	}
 
 	return ro.Map(

--- a/plugins/strings/operator_random_test.go
+++ b/plugins/strings/operator_random_test.go
@@ -72,13 +72,13 @@ func TestRandom(t *testing.T) {
 	is.Equal("AAAAAAAAAA", values3[0])
 	is.Nil(err)
 
-	is.PanicsWithValue(
+	is.PanicsWithError(
 		"rostrings.Random: charset must not be empty",
 		func() {
 			_ = Random[struct{}](100, []rune{})
 		},
 	)
-	is.PanicsWithValue(
+	is.PanicsWithError(
 		"rostrings.Random: size must be greater than 0",
 		func() {
 			_ = Random[struct{}](0, LowerCaseLettersCharset)

--- a/plugins/websocket/client/errors.go
+++ b/plugins/websocket/client/errors.go
@@ -1,0 +1,23 @@
+// Copyright 2025 samber.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/samber/ro/blob/main/licenses/LICENSE.apache.md
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rowebsocketclient
+
+import "errors"
+
+var (
+	ErrWebsocketSubjectURLRequired           = errors.New("rowebsocket.NewWebsocketSubject: URL is required")
+	ErrWebsocketSubjectSerializerRequired    = errors.New("rowebsocket.NewWebsocketSubject: Serializer is required")
+	ErrWebsocketSubjectDeserializerRequired  = errors.New("rowebsocket.NewWebsocketSubject: Deserializer is required")
+)

--- a/plugins/websocket/client/subject.go
+++ b/plugins/websocket/client/subject.go
@@ -45,13 +45,13 @@ type WebsocketSubjectConfig[In any, Out any] struct {
 // NewWebsocketSubject creates a websocket subject that can both send and receive messages from a websocket endpoint.
 func NewWebsocketSubject[In any, Out any](config WebsocketSubjectConfig[In, Out]) *websocketSubject[In, Out] {
 	if config.URL == "" {
-		panic("rowebsocket.NewWebsocketSubject: URL is required")
+		panic(ErrWebsocketSubjectURLRequired)
 	}
 	if config.Serializer == nil {
-		panic("rowebsocket.NewWebsocketSubject: Serializer is required")
+		panic(ErrWebsocketSubjectSerializerRequired)
 	}
 	if config.Deserializer == nil {
-		panic("rowebsocket.NewWebsocketSubject: Deserializer is required")
+		panic(ErrWebsocketSubjectDeserializerRequired)
 	}
 	if config.Dialer == nil {
 		config.Dialer = websocket.DefaultDialer


### PR DESCRIPTION
## Summary

- Replace `panic("string")` and `panic(fmt.Errorf(...))` in plugins with pre-declared sentinel error variables, matching the convention established in the core `errors.go`
- Create a dedicated `errors.go` file in each affected plugin: `plugins/bytes`, `plugins/strings`, `plugins/hyperloglog`, `plugins/websocket/client`
- Update tests to use `PanicsWithError` instead of `PanicsWithValue` (since panic value is now an `error`, not a `string`)
- Document the error convention in `docs/docs/contributing.md`

## Affected plugins

| Plugin | Change |
|--------|--------|
| `plugins/bytes` | `panic("string")` → `panic(ErrRandomWrongSize)` / `panic(ErrRandomEmptyCharset)` |
| `plugins/strings` | `panic("string")` → `panic(ErrRandomWrongSize)` / `panic(ErrRandomEmptyCharset)` |
| `plugins/hyperloglog` | `panic(fmt.Errorf(...))` → `panic(ErrInvalidPrecision)` (moved to `errors.go`, uses `errors.New`) |
| `plugins/websocket/client` | `panic("string")` → `panic(ErrWebsocketSubjectURLRequired)` etc. |

Plugins already correct (no change): `plugins/ozzo/ozzo-validation`, `plugins/exp/simd`.