### PR TITLE
docs: improve contributing documentation for agentic workflows

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - 'docs/**'
   push:
+    branch:
+      - main
     paths:
       - 'docs/**'
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'docs/**'
   push:
-    branch:
+    branches:
       - main
     paths:
       - 'docs/**'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,21 @@ Full guides: [`docs/docs/contributing.md`](docs/docs/contributing.md) (contribut
 - **License headers**: All `.go` files require license headers (`licenses/header.apache.txt` for open source, `licenses/header.ee.txt` for `ee/`). Run `make lint` to verify. Full license texts: [`licenses/LICENSE.apache.md`](licenses/LICENSE.apache.md) (Apache 2.0, open-source code) and [`licenses/LICENSE.ee.md`](licenses/LICENSE.ee.md) (EE code under `ee/`)
 - **Update the documentation**: when updating a feature of the project, you MUST update the documentation. See @./docs/CLAUDE.md
 
+## Definition of Done
+
+When adding or modifying an operator, confirm these steps before opening a PR:
+
+1. Follow the **end-to-end checklist** in [`docs/docs/hacking.md`](docs/docs/hacking.md#add--port-an-operator-end-to-end).
+2. `make test` passes (race detector enabled).
+3. `make lint` passes — or run `make lint-fix` to auto-correct license headers.
+4. Doc files updated: `docs/data/<name>.md` + `docs/static/llms.txt`.
+
+**Workspace pitfalls:**
+
+- Several plugins are **commented out of `go.work`** because they require a newer Go version: `cron`, `exp/simd`, `encoding/json/v2`, `ics`, `hyperloglog`, `iter`, `sentry`, `slog`, `zap`, `oops`, `hot`. They are excluded from `make test`.
+- `plugins/exp/simd` requires `GOEXPERIMENT=simd GOWORK=off` to build or test.
+- `go.work.sum` is modified by routine `go` tool calls — do not commit it as a standalone change. Restore with `git checkout go.work.sum` if it appears unintentionally.
+
 ## References
 
 - **Contribution guidelines**: @./docs/docs/contributing.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,8 @@ Other naming patterns:
 
 **Plugins** are separate Go modules under `plugins/`, each with its own `go.mod` and third-party dependencies. They follow the same `func(Observable[T]) Observable[R]` signature pattern and compose with core operators via `Pipe()`. Plugins wrap external libraries (e.g., `zap`, `sentry`, `fsnotify`) or provide domain-specific operators (e.g., JSON encoding, CSV I/O, rate limiting). Import them separately, e.g., `github.com/samber/ro/plugins/encoding/json`.
 
+> **Rule**: never add a third-party library dependency to the core `ro` package. If an operator requires an external library, it belongs in a plugin under `plugins/`.
+
 ## Testing Conventions
 
 - Tests use `testify` assertions and `go.uber.org/goleak` for goroutine leak detection

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -271,7 +271,7 @@ If the documentation is created at the same time of the helper source code, then
 
 ## Validation Scripts (CI only)
 
-The `docs/scripts/` directory contains documentation validation scripts (exposed via `docs/package.json`). They check cross-references, frontmatter consistency, signature sync, and more. **These scripts are run automatically by CI — you do not need to run them manually.** Your responsibility is to follow the doc format described in this file and the [end-to-end checklist in hacking.md](../docs/hacking.md#add--port-an-operator-end-to-end).
+The `docs/scripts/` directory contains documentation validation scripts (exposed via `docs/package.json`). They check cross-references, frontmatter consistency, signature sync, and more. **These scripts are run automatically by CI — you do not need to run them manually.** Your responsibility is to follow the doc format described in this file and the [end-to-end checklist in hacking.md](./docs/hacking.md#add--port-an-operator-end-to-end).
 
 To validate your work locally, run the standard Go checks from the repository root:
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -269,22 +269,15 @@ func Map[T, R any](project func(item T) R) func(Observable[T]) Observable[R] {
 
 If the documentation is created at the same time of the helper source code, then the Go playground execution might fail, since we need to merge+release the source code first to make this new helper available to Go playground compiler. In that case, skip the creation of the example and set no URL.
 
-## Validation Scripts
+## Validation Scripts (CI only)
 
-Run these scripts to validate your documentation:
+The `docs/scripts/` directory contains documentation validation scripts (exposed via `docs/package.json`). They check cross-references, frontmatter consistency, signature sync, and more. **These scripts are run automatically by CI — you do not need to run them manually.** Your responsibility is to follow the doc format described in this file and the [end-to-end checklist in hacking.md](../docs/hacking.md#add--port-an-operator-end-to-end).
+
+To validate your work locally, run the standard Go checks from the repository root:
 
 ```bash
-# Check cross-references
-node scripts/check-cross-references.js
-
-# Check filename matches frontmatter
-node scripts/check-filename-matches-frontmatter.js
-
-# Check for similar existing helpers
-node scripts/check-similar-exists.js
-
-# Check for similar keys in directory
-node scripts/check-similar-keys-exist-in-directory.js
+make test   # Go tests with race detector
+make lint   # golangci-lint + license headers (make lint-fix to auto-correct)
 ```
 
 ## Examples: Complete Files
@@ -369,5 +362,5 @@ Before submitting:
 - [ ] Expected output is shown as a comment
 - [ ] Similar helpers are listed if applicable
 - [ ] Related helpers are consolidated into single file when appropriate
-- [ ] All validation scripts pass without errors
+- [ ] Markdown doc follows the format above (CI runs the validation scripts automatically)
 - [ ] Helper is added to llms.txt

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -216,6 +216,40 @@ func MyOperator(param int) func(ro.Observable[T]) ro.Observable[T] {
 - Never write `panic("some string")` or `panic(errors.New("..."))` inline — always use a pre-declared variable.
 - Panics are reserved for programmer errors detected at construction time (invalid parameters), never for runtime stream errors.
 
+## Upstream parity
+
+Some operators re-implement algorithms from a sibling library (`samber/lo`); others simply wrap it. These two cases require different maintenance strategies.
+
+### Mode 1 — Re-implemented code (manual sync)
+
+`plugins/strings/operator_*.go` and `plugins/bytes/operator_*.go` contain operators whose logic is **copied from `github.com/samber/lo`** (`string.go`). The affected functions include `words`, `capitalize`, `pascalcase`, `camelcase`, `snakecase`, `kebabcase`, `ellipsis`, `random`, and the case-conversion helpers. Any bug fix or improvement in `samber/lo` must be ported manually to both plugins (code, tests, and doc).
+
+Each file that copies upstream logic carries a header comment:
+
+```go
+// Ported from github.com/samber/lo (string.go) — keep in sync.
+```
+
+If you modify one of these operators and the change improves algorithm correctness (not just the reactive wrapping), check whether `samber/lo` has already applied the same fix, and vice-versa.
+
+**Known divergence**: `bytes.ToLower` produces `U+FFFD` on invalid UTF-8, whereas `cases.Lower(...).Bytes()` preserves raw bytes. This is intentional; do not "fix" it to match `lo` without understanding the impact on byte-level consumers.
+
+### Mode 2 — Wrapped library (go.mod bump)
+
+These plugins **import** the sibling library and call its API; they do not copy logic. Synchronize by bumping the dependency version in `go.mod`:
+
+- `plugins/samber/hot` → `github.com/samber/hot`
+- `plugins/samber/psi` → `github.com/samber/psi`
+- `plugins/iter` → iterator library
+- `plugins/testify` → testify helpers
+- `plugins/ozzo/ozzo-validation` → ozzo-validation
+
+The **core `ro` module** also imports `samber/lo` (e.g., `lo.Must`), but only as a general utility — this is not a parity case.
+
+### General rule
+
+Before modifying an operator, determine whether it **re-implements** upstream logic (sync code + tests + doc, maintain the provenance comment) or **wraps** it (bump `go.mod`). Any file that copies upstream logic MUST carry `// Ported from … — keep in sync.`
+
 ## Other conventions
 
 ### Naming

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -165,6 +165,10 @@ Feel free to write benchmarks.
 
 Sources can be unbounded and might run for a very long time. If you expect a big memory footprint, please warn developers in the operator comment.
 
+## Core vs plugins
+
+**Never add a third-party library dependency to the core `ro` package.** If an operator requires wrapping an external library, it must live in a dedicated plugin under `plugins/` with its own `go.mod`. The core package only depends on `samber/lo`.
+
 ## Documentation
 
 Operators must be properly commented, with a Go Playground link and a markdown documentation in `docs/data/`. In markdown header, please link to similar helpers (and update other markdowns accordingly).

--- a/docs/docs/hacking.md
+++ b/docs/docs/hacking.md
@@ -309,6 +309,54 @@ Test more edge cases:
 - If your operator uses functions that are passed in as parameters (predicates, for instance), note that these may be sources of errors, and be prepared to catch these and notify subscribers via `Error()` calls.
 - In general, notify subscribers of error conditions immediately, rather than making an effort to emit more items first.
 
+## Add / port an operator end-to-end
+
+Follow this checklist in order when adding a new operator or porting one from a sibling library. Each step maps to a concrete file in the repository.
+
+1. **Operator code + variants**: implement the base operator and all applicable variants in the correct suffix order: `Err` → `I` → `WithContext` (e.g., `Map`, `MapErr`, `MapI`, `MapErrI`, `MapWithContext`, `MapErrWithContext`, `MapIWithContext`, `MapErrIWithContext`).
+2. **Error sentinels**: if the operator validates its parameters, declare sentinel variables in `errors.go` using the pattern `Err{OperatorName}{WhatIsWrong}`. Never `panic("string")` inline.
+3. **Tests**: write tests using `Collect(...)` with at minimum:
+   - `Empty[T]()` (empty source)
+   - `Throw[T](assert.AnError)` (error propagation)
+   - Early unsubscription
+   - Context propagation and cancellation
+4. **Godoc example**: add an example function in `ro_example_test.go` (core) or `plugins/<x>/operator_example_test.go` (plugin). It will appear on https://pkg.go.dev.
+5. **Go Playground link**: create a runnable snippet via the `mcp__go-playground__run_and_share_go_code` MCP tool, verify it executes correctly, then add `// Play: https://go.dev/play/p/...` above the function signature. Leave the URL empty if the operator is not yet published (new code not yet released cannot compile on the Playground).
+6. **Markdown doc**: create `docs/data/(core|plugin)-<name>.md` with complete frontmatter (`sourceRef`, `signatures`, `variantHelpers`, `similarHelpers`, `playUrl`, `position`). See [`docs/CLAUDE.md`](../CLAUDE.md) for the full format.
+7. **llms.txt**: add a one-line entry for the operator in `docs/static/llms.txt`.
+8. **Upstream parity**: if the operator re-implements logic from a sibling library, synchronize it. See [Upstream parity](./contributing#upstream-parity) in contributing.md.
+9. **Verify**: run `make test` (race detector) and `make lint`. Documentation validation scripts run in CI — you do not need to run them manually.
+
+## Common agent pitfalls
+
+These issues have recurred across multiple sessions. Read them before starting.
+
+- **`PrintObserver[[]byte]()`** prints raw integer slices (`[196 176 ...]`), not strings. For byte-slice observables, write a custom observer that calls `fmt.Println(string(data))`.
+- **`context.TODO()` in goroutines breaks the context chain.** Any goroutine spawned inside a plugin operator must capture and forward `subscriberCtx`, not create an independent context. Using `context.TODO()` silently breaks cancellation and deadline propagation.
+- **Adding an import before its first usage** causes `imported and not used` compile errors. Add the import and its usage in the same edit.
+- **`go.work.sum` churn**: the workspace sum file is modified by routine `go` tool invocations. Do not commit it unless it is the only intentional change. Restore with `git checkout go.work.sum` when it appears as an unintentional modification.
+- **Porting from `samber/lo` — bytes UTF-8 divergence**: `bytes.ToLower` via `strings.ToLower` produces `U+FFFD` replacement characters on invalid UTF-8, whereas `cases.Lower(...).Bytes()` preserves the raw bytes. Adjust test fixtures accordingly when porting from `samber/lo` string helpers to the `bytes` plugin.
+
+## Definition of done
+
+Before opening a PR, confirm:
+
+```bash
+make test   # runs all tests with the race detector
+make lint   # runs golangci-lint + license header check (make lint-fix to auto-correct)
+```
+
+To test a single plugin module without running the whole workspace:
+
+```bash
+cd plugins/<x> && go test -race ./...
+```
+
+**Known pre-existing failures — do not confuse with your own changes:**
+
+- `bench/` and `plugins/exp/simd/` fail under a plain `go build`/`go test` because `exp/simd` requires `GOEXPERIMENT=simd GOWORK=off`.
+- Several plugins are commented out of `go.work` because they require a newer Go version than the workspace default: `cron`, `exp/simd`, `encoding/json/v2`, `ics`, `hyperloglog`, `iter`, `sentry`, `slog`, `zap`, `oops`, `hot`. They are excluded from `make test`.
+
 ## Next Steps
 
 - **[Operators Reference](./operator/)** - Learn about existing operators for inspiration

--- a/docs/docs/hacking.md
+++ b/docs/docs/hacking.md
@@ -324,7 +324,7 @@ Follow this checklist in order when adding a new operator or porting one from a 
 5. **Go Playground link**: create a runnable snippet via the `mcp__go-playground__run_and_share_go_code` MCP tool, verify it executes correctly, then add `// Play: https://go.dev/play/p/...` above the function signature. Leave the URL empty if the operator is not yet published (new code not yet released cannot compile on the Playground).
 6. **Markdown doc**: create `docs/data/(core|plugin)-<name>.md` with complete frontmatter (`sourceRef`, `signatures`, `variantHelpers`, `similarHelpers`, `playUrl`, `position`). See `docs/CLAUDE.md` at the repository root for the full format.
 7. **llms.txt**: add a one-line entry for the operator in `docs/static/llms.txt`.
-8. **Upstream parity**: if the operator re-implements logic from a sibling library, synchronize it. See [Upstream parity](./contributing#upstream-parity) in contributing.md.
+8. **Upstream parity**: if the operator re-implements logic from a sibling library, synchronize it. See the [Upstream parity](./contributing) section in contributing.md.
 9. **Verify**: run `make test` (race detector) and `make lint`. Documentation validation scripts run in CI — you do not need to run them manually.
 
 ## Common agent pitfalls

--- a/docs/docs/hacking.md
+++ b/docs/docs/hacking.md
@@ -322,7 +322,7 @@ Follow this checklist in order when adding a new operator or porting one from a 
    - Context propagation and cancellation
 4. **Godoc example**: add an example function in `ro_example_test.go` (core) or `plugins/<x>/operator_example_test.go` (plugin). It will appear on https://pkg.go.dev.
 5. **Go Playground link**: create a runnable snippet via the `mcp__go-playground__run_and_share_go_code` MCP tool, verify it executes correctly, then add `// Play: https://go.dev/play/p/...` above the function signature. Leave the URL empty if the operator is not yet published (new code not yet released cannot compile on the Playground).
-6. **Markdown doc**: create `docs/data/(core|plugin)-<name>.md` with complete frontmatter (`sourceRef`, `signatures`, `variantHelpers`, `similarHelpers`, `playUrl`, `position`). See [`docs/CLAUDE.md`](../CLAUDE.md) for the full format.
+6. **Markdown doc**: create `docs/data/(core|plugin)-<name>.md` with complete frontmatter (`sourceRef`, `signatures`, `variantHelpers`, `similarHelpers`, `playUrl`, `position`). See `docs/CLAUDE.md` at the repository root for the full format.
 7. **llms.txt**: add a one-line entry for the operator in `docs/static/llms.txt`.
 8. **Upstream parity**: if the operator re-implements logic from a sibling library, synchronize it. See [Upstream parity](./contributing#upstream-parity) in contributing.md.
 9. **Verify**: run `make test` (race detector) and `make lint`. Documentation validation scripts run in CI — you do not need to run them manually.


### PR DESCRIPTION
## Summary

- **`docs/docs/hacking.md`**: add ordered end-to-end checklist "Add/port an operator", "Common agent pitfalls" section (real bugs observed in past sessions: `PrintObserver[[]byte]`, `context.TODO()` in goroutines, `go.work.sum` churn, `lo`/bytes UTF-8 divergence), and "Definition of done" with known pre-existing failures.
- **`docs/docs/contributing.md`**: add "Upstream parity" section distinguishing re-implemented code (`strings`/`bytes` ↔ `samber/lo`, manual sync + provenance comment) from wrapped libraries (`go.mod` bump), with a general rule.
- **`docs/CLAUDE.md`**: requalify the "Validation Scripts" block as CI-only; fix the wrong path (`scripts/` → `docs/scripts/`); remove the instruction for agents to run those scripts.
- **`CLAUDE.md`**: add "Definition of done" section with workspace pitfalls (commented-out modules, SIMD flags, `go.work.sum`) and link to the new hacking.md checklist.

## Motivation

Analysis of 14+ past Claude Code sessions on this repo revealed recurring friction: forgotten `llms.txt` entries, missing doc files, `context.TODO()` context chain breaks, `go.work.sum` committed by accident, and agents re-discovering the `samber/lo` parity rule from scratch on each session. This PR makes that institutional knowledge explicit in the docs.