### PR TITLE
docs: note that sourceRef line numbers drift and how to refresh them

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -38,7 +38,7 @@ position: 0
 
 - **name**: The display name of the helper (PascalCase)
 - **slug**: URL-friendly name (kebab-case, matches filename without `core-` prefix)
-- **sourceRef**: Source file reference with line number (format: `operator_conditional.go#L123`)
+- **sourceRef**: Source file reference with line number (format: `operator_conditional.go#L123`). Line numbers drift whenever the referenced Go file is edited (added imports, new operators, reordered code...). After changing a `.go` file, re-check every `sourceRef` pointing into it: run `gopls symbols <file>` to list the file's operators/functions with their current line numbers, then update the affected `sourceRef` fields accordingly.
 - **type**: `core`, `plugin`. The category must match the file name.
 - **category**: The functional category. For plugins, the category must match the file name. Some plugins might have a sub-sub-category: in that case use "-" (eg: plugin > `encoding-json` or plugin > `samber-hot` or plugin > `logger-logrus`).
 - **signatures**: Array of function signatures as strings. Do not list signatures from other type/category.

--- a/docs/data/core-abs.md
+++ b/docs/data/core-abs.md
@@ -1,7 +1,7 @@
 ---
 name: Abs
 slug: abs
-sourceRef: operator_math.go#L228
+sourceRef: operator_math.go#L254
 type: core
 category: math
 signatures:

--- a/docs/data/core-all.md
+++ b/docs/data/core-all.md
@@ -1,7 +1,7 @@
 ---
 name: All
 slug: all
-sourceRef: operator_conditional.go#L24
+sourceRef: operator_conditional.go#L25
 type: core
 category: conditional
 signatures:

--- a/docs/data/core-amb.md
+++ b/docs/data/core-amb.md
@@ -1,7 +1,7 @@
 ---
 name: Amb
 slug: amb
-sourceRef: operator_creation.go#L559
+sourceRef: operator_creation.go#L591
 type: core
 category: combining
 signatures:

--- a/docs/data/core-average.md
+++ b/docs/data/core-average.md
@@ -1,7 +1,7 @@
 ---
 name: Average
 slug: average
-sourceRef: operator_math.go#L24
+sourceRef: operator_math.go#L45
 type: core
 category: math
 signatures:

--- a/docs/data/core-bufferwhen.md
+++ b/docs/data/core-bufferwhen.md
@@ -1,7 +1,7 @@
 ---
 name: BufferWhen
 slug: bufferwhen
-sourceRef: operator_transformations.go#L376
+sourceRef: operator_transformations.go#L396
 type: core
 category: transformation
 signatures:

--- a/docs/data/core-bufferwithcount.md
+++ b/docs/data/core-bufferwithcount.md
@@ -1,7 +1,7 @@
 ---
 name: BufferWithCount
 slug: bufferwithcount
-sourceRef: operator_transformations.go#L426
+sourceRef: operator_transformations.go#L558
 type: core
 category: transformation
 signatures:

--- a/docs/data/core-bufferwithtime.md
+++ b/docs/data/core-bufferwithtime.md
@@ -1,7 +1,7 @@
 ---
 name: BufferWithTime
 slug: bufferwithtime
-sourceRef: operator_transformations.go#L442
+sourceRef: operator_transformations.go#L603
 type: core
 category: transformation
 signatures:

--- a/docs/data/core-bufferwithtimeorcount.md
+++ b/docs/data/core-bufferwithtimeorcount.md
@@ -1,7 +1,7 @@
 ---
 name: BufferWithTimeOrCount
 slug: bufferwithtimeorcount
-sourceRef: operator_transformations.go#L396
+sourceRef: operator_transformations.go#L470
 type: core
 category: transformation
 signatures:

--- a/docs/data/core-catch.md
+++ b/docs/data/core-catch.md
@@ -1,7 +1,7 @@
 ---
 name: Catch
 slug: catch
-sourceRef: operator_error_handling.go#L25
+sourceRef: operator_error_handling.go#L26
 type: core
 category: error-handling
 signatures:

--- a/docs/data/core-ceil.md
+++ b/docs/data/core-ceil.md
@@ -1,7 +1,7 @@
 ---
 name: Ceil
 slug: ceil
-sourceRef: operator_math.go#L268
+sourceRef: operator_math.go#L312
 type: core
 category: math
 signatures:

--- a/docs/data/core-clamp.md
+++ b/docs/data/core-clamp.md
@@ -1,7 +1,7 @@
 ---
 name: Clamp
 slug: clamp
-sourceRef: operator_math.go#L197
+sourceRef: operator_math.go#L222
 type: core
 category: math
 signatures:

--- a/docs/data/core-collect.md
+++ b/docs/data/core-collect.md
@@ -1,7 +1,7 @@
 ---
 name: Collect
 slug: collect
-sourceRef: observable.go#L327
+sourceRef: observable.go#L328
 type: core
 category: sink
 signatures:

--- a/docs/data/core-combinelatest.md
+++ b/docs/data/core-combinelatest.md
@@ -1,7 +1,7 @@
 ---
 name: CombineLatest
 slug: combinelatest
-sourceRef: operator_creation.go#L438
+sourceRef: operator_creation.go#L484
 type: core
 category: combining
 signatures:

--- a/docs/data/core-combinelatestall.md
+++ b/docs/data/core-combinelatestall.md
@@ -1,7 +1,7 @@
 ---
 name: CombineLatestAll
 slug: combinelatestall
-sourceRef: operator_combining.go#L56
+sourceRef: operator_combining.go#L758
 type: core
 category: combining
 signatures:

--- a/docs/data/core-combinelatestwith.md
+++ b/docs/data/core-combinelatestwith.md
@@ -1,7 +1,7 @@
 ---
 name: CombineLatestWith
 slug: combinelatestwith
-sourceRef: operator_combining.go#L26
+sourceRef: operator_combining.go#L235
 type: core
 category: combining
 signatures:

--- a/docs/data/core-concat.md
+++ b/docs/data/core-concat.md
@@ -1,7 +1,7 @@
 ---
 name: Concat
 slug: concat
-sourceRef: operator_creation.go#L144
+sourceRef: operator_creation.go#L571
 type: core
 category: combining
 signatures:

--- a/docs/data/core-contains.md
+++ b/docs/data/core-contains.md
@@ -1,7 +1,7 @@
 ---
 name: Contains
 slug: contains
-sourceRef: operator_conditional.go#L74
+sourceRef: operator_conditional.go#L78
 type: core
 category: conditional
 signatures:

--- a/docs/data/core-contextmap.md
+++ b/docs/data/core-contextmap.md
@@ -1,7 +1,7 @@
 ---
 name: ContextMap
 slug: contextmap
-sourceRef: operator_context.go#L160
+sourceRef: operator_context.go#L217
 type: core
 category: context
 signatures:

--- a/docs/data/core-contextreset.md
+++ b/docs/data/core-contextreset.md
@@ -1,7 +1,7 @@
 ---
 name: ContextReset
 slug: contextreset
-sourceRef: operator_context.go#L129
+sourceRef: operator_context.go#L185
 type: core
 category: context
 signatures:

--- a/docs/data/core-contextwithdeadline.md
+++ b/docs/data/core-contextwithdeadline.md
@@ -1,7 +1,7 @@
 ---
 name: ContextWithDeadline
 slug: contextwithdeadline
-sourceRef: operator_context.go#L91
+sourceRef: operator_context.go#L120
 type: core
 category: context
 signatures:

--- a/docs/data/core-contextwithtimeout.md
+++ b/docs/data/core-contextwithtimeout.md
@@ -1,7 +1,7 @@
 ---
 name: ContextWithTimeout
 slug: contextwithtimeout
-sourceRef: operator_context.go#L53
+sourceRef: operator_context.go#L55
 type: core
 category: context
 signatures:

--- a/docs/data/core-contextwithvalue.md
+++ b/docs/data/core-contextwithvalue.md
@@ -1,7 +1,7 @@
 ---
 name: ContextWithValue
 slug: contextwithvalue
-sourceRef: operator_context.go#L24
+sourceRef: operator_context.go#L25
 type: core
 category: context
 signatures:

--- a/docs/data/core-count.md
+++ b/docs/data/core-count.md
@@ -1,7 +1,7 @@
 ---
 name: Count
 slug: count
-sourceRef: operator_math.go#L60
+sourceRef: operator_math.go#L80
 type: core
 category: math
 signatures:

--- a/docs/data/core-defaultifempty.md
+++ b/docs/data/core-defaultifempty.md
@@ -1,7 +1,7 @@
 ---
 name: DefaultIfEmpty
 slug: defaultifempty
-sourceRef: operator_conditional.go#L187
+sourceRef: operator_conditional.go#L198
 type: core
 category: conditional
 signatures:

--- a/docs/data/core-defer.md
+++ b/docs/data/core-defer.md
@@ -1,7 +1,7 @@
 ---
 name: Defer
 slug: defer
-sourceRef: operator_creation.go#L422
+sourceRef: operator_creation.go#L440
 type: core
 category: creation
 signatures:

--- a/docs/data/core-delay.md
+++ b/docs/data/core-delay.md
@@ -1,7 +1,7 @@
 ---
 name: Delay
 slug: delay
-sourceRef: operator_utility.go#L278
+sourceRef: operator_utility.go#L293
 type: core
 category: utility
 signatures:

--- a/docs/data/core-dematerialize.md
+++ b/docs/data/core-dematerialize.md
@@ -1,7 +1,7 @@
 ---
 name: Dematerialize
 slug: dematerialize
-sourceRef: operator_utility.go#L488
+sourceRef: operator_utility.go#L508
 type: core
 category: utility
 signatures:

--- a/docs/data/core-distinct.md
+++ b/docs/data/core-distinct.md
@@ -1,7 +1,7 @@
 ---
 name: Distinct
 slug: distinct
-sourceRef: operator_filter.go#L73
+sourceRef: operator_filter.go#L78
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-distinctby.md
+++ b/docs/data/core-distinctby.md
@@ -1,7 +1,7 @@
 ---
 name: DistinctBy
 slug: distinctby
-sourceRef: operator_filter.go#L98
+sourceRef: operator_filter.go#L105
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-do.md
+++ b/docs/data/core-do.md
@@ -1,7 +1,7 @@
 ---
 name: Do
 slug: do
-sourceRef: operator_utility.go#L74
+sourceRef: operator_utility.go#L78
 type: core
 category: utility
 signatures:

--- a/docs/data/core-dowhile.md
+++ b/docs/data/core-dowhile.md
@@ -1,7 +1,7 @@
 ---
 name: DoWhile
 slug: dowhile
-sourceRef: operator_error_handling.go#L260
+sourceRef: operator_error_handling.go#L259
 type: core
 category: error-handling
 signatures:

--- a/docs/data/core-elementat.md
+++ b/docs/data/core-elementat.md
@@ -1,7 +1,7 @@
 ---
 name: ElementAt
 slug: elementat
-sourceRef: operator_filter.go#L682
+sourceRef: operator_filter.go#L738
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-elementatordefault.md
+++ b/docs/data/core-elementatordefault.md
@@ -1,7 +1,7 @@
 ---
 name: ElementAtOrDefault
 slug: elementatordefault
-sourceRef: operator_filter.go#L717
+sourceRef: operator_filter.go#L774
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-empty.md
+++ b/docs/data/core-empty.md
@@ -1,7 +1,7 @@
 ---
 name: Empty
 slug: empty
-sourceRef: operator_creation.go#L38
+sourceRef: operator_creation.go#L385
 type: core
 category: creation
 signatures:

--- a/docs/data/core-filter.md
+++ b/docs/data/core-filter.md
@@ -1,7 +1,7 @@
 ---
 name: Filter
 slug: filter
-sourceRef: operator_filter.go#L25
+sourceRef: operator_filter.go#L26
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-find.md
+++ b/docs/data/core-find.md
@@ -1,7 +1,7 @@
 ---
 name: Find
 slug: find
-sourceRef: operator_conditional.go#L126
+sourceRef: operator_conditional.go#L133
 type: core
 category: conditional
 signatures:

--- a/docs/data/core-first.md
+++ b/docs/data/core-first.md
@@ -1,7 +1,7 @@
 ---
 name: First
 slug: first
-sourceRef: operator_filter.go#L566
+sourceRef: operator_filter.go#L620
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-flatmap.md
+++ b/docs/data/core-flatmap.md
@@ -1,7 +1,7 @@
 ---
 name: FlatMap
 slug: flatmap
-sourceRef: operator_transformations.go#L149
+sourceRef: operator_transformations.go#L159
 type: core
 category: transformation
 signatures:

--- a/docs/data/core-floor-with-precision.md
+++ b/docs/data/core-floor-with-precision.md
@@ -1,7 +1,7 @@
 ---
 name: FloorWithPrecision
 slug: floor-with-precision
-sourceRef: operator_math.go#L296
+sourceRef: operator_math.go#L306
 type: core
 category: math
 signatures:

--- a/docs/data/core-floor.md
+++ b/docs/data/core-floor.md
@@ -1,7 +1,7 @@
 ---
 name: Floor
 slug: floor
-sourceRef: operator_math.go#L248
+sourceRef: operator_math.go#L275
 type: core
 category: math
 signatures:

--- a/docs/data/core-fromchannel.md
+++ b/docs/data/core-fromchannel.md
@@ -1,7 +1,7 @@
 ---
 name: FromChannel
 slug: fromchannel
-sourceRef: operator_creation.go#L110
+sourceRef: operator_creation.go#L340
 type: core
 category: creation
 signatures:

--- a/docs/data/core-fromslice.md
+++ b/docs/data/core-fromslice.md
@@ -1,7 +1,7 @@
 ---
 name: FromSlice
 slug: fromslice
-sourceRef: operator_creation.go#L114
+sourceRef: operator_creation.go#L369
 type: core
 category: creation
 signatures:

--- a/docs/data/core-future.md
+++ b/docs/data/core-future.md
@@ -1,7 +1,7 @@
 ---
 name: Future
 slug: future
-sourceRef: operator_creation.go#L62
+sourceRef: operator_creation.go#L454
 type: core
 category: creation
 signatures:

--- a/docs/data/core-groupby.md
+++ b/docs/data/core-groupby.md
@@ -1,7 +1,7 @@
 ---
 name: GroupBy
 slug: groupby
-sourceRef: operator_transformations.go#L293
+sourceRef: operator_transformations.go#L311
 type: core
 category: transformation
 signatures:

--- a/docs/data/core-head.md
+++ b/docs/data/core-head.md
@@ -1,7 +1,7 @@
 ---
 name: Head
 slug: head
-sourceRef: operator_filter.go#L509
+sourceRef: operator_filter.go#L562
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-ignoreelements.md
+++ b/docs/data/core-ignoreelements.md
@@ -1,7 +1,7 @@
 ---
 name: IgnoreElements
 slug: ignoreelements
-sourceRef: operator_filter.go#L101
+sourceRef: operator_filter.go#L143
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-iif.md
+++ b/docs/data/core-iif.md
@@ -1,7 +1,7 @@
 ---
 name: Iif
 slug: iif
-sourceRef: operator_conditional.go#L176
+sourceRef: operator_conditional.go#L186
 type: core
 category: conditional
 signatures:

--- a/docs/data/core-interval.md
+++ b/docs/data/core-interval.md
@@ -1,7 +1,7 @@
 ---
 name: Interval
 slug: interval
-sourceRef: operator_creation.go#L75
+sourceRef: operator_creation.go#L85
 type: core
 category: creation
 signatures:

--- a/docs/data/core-intervalwithinitial.md
+++ b/docs/data/core-intervalwithinitial.md
@@ -1,7 +1,7 @@
 ---
 name: IntervalWithInitial
 slug: intervalwithinitial
-sourceRef: operator_creation.go#L80
+sourceRef: operator_creation.go#L122
 type: core
 category: creation
 signatures:

--- a/docs/data/core-just.md
+++ b/docs/data/core-just.md
@@ -1,7 +1,7 @@
 ---
 name: Just
 slug: just
-sourceRef: operator_creation.go#L40
+sourceRef: operator_creation.go#L42
 type: core
 category: creation
 signatures:

--- a/docs/data/core-last.md
+++ b/docs/data/core-last.md
@@ -1,7 +1,7 @@
 ---
 name: Last
 slug: last
-sourceRef: operator_filter.go#L620
+sourceRef: operator_filter.go#L675
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-map.md
+++ b/docs/data/core-map.md
@@ -1,7 +1,7 @@
 ---
 name: Map
 slug: map
-sourceRef: operator_transformations.go#L29
+sourceRef: operator_transformations.go#L30
 type: core
 category: transformation
 signatures:

--- a/docs/data/core-maperr.md
+++ b/docs/data/core-maperr.md
@@ -1,7 +1,7 @@
 ---
 name: MapErr
 slug: maperr
-sourceRef: operator_transformations.go#L96
+sourceRef: operator_transformations.go#L102
 type: core
 category: transformation
 signatures:

--- a/docs/data/core-materialize.md
+++ b/docs/data/core-materialize.md
@@ -1,7 +1,7 @@
 ---
 name: Materialize
 slug: materialize
-sourceRef: operator_utility.go#L462
+sourceRef: operator_utility.go#L481
 type: core
 category: utility
 signatures:

--- a/docs/data/core-max.md
+++ b/docs/data/core-max.md
@@ -1,7 +1,7 @@
 ---
 name: Max
 slug: max
-sourceRef: operator_math.go#L167
+sourceRef: operator_math.go#L191
 type: core
 category: math
 signatures:

--- a/docs/data/core-merge.md
+++ b/docs/data/core-merge.md
@@ -1,7 +1,7 @@
 ---
 name: Merge
 slug: merge
-sourceRef: operator_combining.go#L27
+sourceRef: operator_creation.go#L476
 type: core
 category: combining
 signatures:

--- a/docs/data/core-mergeall.md
+++ b/docs/data/core-mergeall.md
@@ -1,7 +1,7 @@
 ---
 name: MergeAll
 slug: mergeall
-sourceRef: operator_combining.go#L76
+sourceRef: operator_combining.go#L115
 type: core
 category: combining
 signatures:

--- a/docs/data/core-mergemap.md
+++ b/docs/data/core-mergemap.md
@@ -1,7 +1,7 @@
 ---
 name: MergeMap
 slug: mergemap
-sourceRef: operator_combining.go#L108
+sourceRef: operator_combining.go#L177
 type: core
 category: combining
 signatures:

--- a/docs/data/core-mergewith.md
+++ b/docs/data/core-mergewith.md
@@ -1,7 +1,7 @@
 ---
 name: MergeWith
 slug: mergewith
-sourceRef: operator_creation.go#L451
+sourceRef: operator_combining.go#L35
 type: core
 category: combining
 signatures:

--- a/docs/data/core-min.md
+++ b/docs/data/core-min.md
@@ -1,7 +1,7 @@
 ---
 name: Min
 slug: min
-sourceRef: operator_math.go#L133
+sourceRef: operator_math.go#L156
 type: core
 category: math
 signatures:

--- a/docs/data/core-never.md
+++ b/docs/data/core-never.md
@@ -1,7 +1,7 @@
 ---
 name: Never
 slug: never
-sourceRef: operator_creation.go#L42
+sourceRef: operator_creation.go#L396
 type: core
 category: creation
 signatures:

--- a/docs/data/core-observeon.md
+++ b/docs/data/core-observeon.md
@@ -1,7 +1,7 @@
 ---
 name: ObserveOn
 slug: observeon
-sourceRef: scheduler.go#L81
+sourceRef: operator_utility.go#L569
 type: core
 category: utility
 signatures:

--- a/docs/data/core-onerrorresumenextwith.md
+++ b/docs/data/core-onerrorresumenextwith.md
@@ -1,7 +1,7 @@
 ---
 name: OnErrorResumeNextWith
 slug: onerrorresumenextwith
-sourceRef: operator_error_handling.go#L53
+sourceRef: operator_error_handling.go#L55
 type: core
 category: error-handling
 signatures:

--- a/docs/data/core-onerrorreturn.md
+++ b/docs/data/core-onerrorreturn.md
@@ -1,7 +1,7 @@
 ---
 name: OnErrorReturn
 slug: onerrorreturn
-sourceRef: operator_error_handling.go#L108
+sourceRef: operator_error_handling.go#L111
 type: core
 category: error-handling
 signatures:

--- a/docs/data/core-pairwise.md
+++ b/docs/data/core-pairwise.md
@@ -1,7 +1,7 @@
 ---
 name: Pairwise
 slug: pairwise
-sourceRef: operator_combining.go#L945
+sourceRef: operator_combining.go#L974
 type: core
 category: combining
 signatures:

--- a/docs/data/core-race.md
+++ b/docs/data/core-race.md
@@ -1,7 +1,7 @@
 ---
 name: Race
 slug: race
-sourceRef: operator_creation.go#L550
+sourceRef: operator_creation.go#L581
 type: core
 category: combining
 signatures:

--- a/docs/data/core-randfloat64.md
+++ b/docs/data/core-randfloat64.md
@@ -1,7 +1,7 @@
 ---
 name: RandFloat64
 slug: randfloat64
-sourceRef: operator_creation.go#L122
+sourceRef: operator_creation.go#L613
 type: core
 category: creation
 signatures:

--- a/docs/data/core-randintn.md
+++ b/docs/data/core-randintn.md
@@ -1,7 +1,7 @@
 ---
 name: RandIntN
 slug: randintn
-sourceRef: operator_creation.go#L118
+sourceRef: operator_creation.go#L598
 type: core
 category: creation
 signatures:

--- a/docs/data/core-range.md
+++ b/docs/data/core-range.md
@@ -1,7 +1,7 @@
 ---
 name: Range
 slug: range
-sourceRef: operator_creation.go#L168
+sourceRef: operator_creation.go#L180
 type: core
 category: creation
 signatures:

--- a/docs/data/core-rangewithinterval.md
+++ b/docs/data/core-rangewithinterval.md
@@ -1,7 +1,7 @@
 ---
 name: RangeWithInterval
 slug: rangewithinterval
-sourceRef: operator_creation.go#L168
+sourceRef: operator_creation.go#L245
 type: core
 category: creation
 signatures:

--- a/docs/data/core-rangewithstep.md
+++ b/docs/data/core-rangewithstep.md
@@ -1,7 +1,7 @@
 ---
 name: RangeWithStep
 slug: rangewithstep
-sourceRef: operator_creation.go#L168
+sourceRef: operator_creation.go#L210
 type: core
 category: creation
 signatures:

--- a/docs/data/core-rangewithstepandinterval.md
+++ b/docs/data/core-rangewithstepandinterval.md
@@ -1,7 +1,7 @@
 ---
 name: RangeWithStepAndInterval
 slug: rangewithstepandinterval
-sourceRef: operator_creation.go#L168
+sourceRef: operator_creation.go#L275
 type: core
 category: creation
 signatures:

--- a/docs/data/core-reduce.md
+++ b/docs/data/core-reduce.md
@@ -1,7 +1,7 @@
 ---
 name: Reduce
 slug: reduce
-sourceRef: operator_math.go#L310
+sourceRef: operator_math.go#L819
 type: core
 category: math
 signatures:

--- a/docs/data/core-repeat.md
+++ b/docs/data/core-repeat.md
@@ -1,7 +1,7 @@
 ---
 name: Repeat
 slug: repeat
-sourceRef: operator_creation.go#L70
+sourceRef: operator_creation.go#L300
 type: core
 category: creation
 signatures:

--- a/docs/data/core-repeatwithinterval.md
+++ b/docs/data/core-repeatwithinterval.md
@@ -1,7 +1,7 @@
 ---
 name: RepeatWithInterval
 slug: repeatwithinterval
-sourceRef: operator_creation.go#L74
+sourceRef: operator_creation.go#L322
 type: core
 category: creation
 signatures:

--- a/docs/data/core-retry.md
+++ b/docs/data/core-retry.md
@@ -1,7 +1,7 @@
 ---
 name: Retry
 slug: retry
-sourceRef: operator_error_handling.go#L131
+sourceRef: operator_error_handling.go#L135
 type: core
 category: error-handling
 signatures:

--- a/docs/data/core-round.md
+++ b/docs/data/core-round.md
@@ -1,7 +1,7 @@
 ---
 name: Round
 slug: round
-sourceRef: operator_math.go#L110
+sourceRef: operator_math.go#L133
 type: core
 category: math
 signatures:

--- a/docs/data/core-scan.md
+++ b/docs/data/core-scan.md
@@ -1,7 +1,7 @@
 ---
 name: Scan
 slug: scan
-sourceRef: operator_transformations.go#L245
+sourceRef: operator_transformations.go#L261
 type: core
 category: transformation
 signatures:

--- a/docs/data/core-sequenceequal.md
+++ b/docs/data/core-sequenceequal.md
@@ -1,7 +1,7 @@
 ---
 name: SequenceEqual
 slug: sequenceequal
-sourceRef: operator_conditional.go#L222
+sourceRef: operator_conditional.go#L234
 type: core
 category: conditional
 signatures:

--- a/docs/data/core-serialize.md
+++ b/docs/data/core-serialize.md
@@ -1,7 +1,7 @@
 ---
 name: Serialize
 slug: serialize
-sourceRef: operator_utility.go#L634
+sourceRef: operator_utility.go#L657
 type: core
 category: utility
 signatures:

--- a/docs/data/core-share.md
+++ b/docs/data/core-share.md
@@ -1,7 +1,7 @@
 ---
 name: Share
 slug: share
-sourceRef: operator_connectable.go#L38
+sourceRef: operator_connectable.go#L39
 type: core
 category: connectable
 signatures:

--- a/docs/data/core-sharereplay.md
+++ b/docs/data/core-sharereplay.md
@@ -1,7 +1,7 @@
 ---
 name: ShareReplay
 slug: sharereplay
-sourceRef: operator_connectable.go#L195
+sourceRef: operator_connectable.go#L197
 type: core
 category: connectable
 signatures:

--- a/docs/data/core-sharereplaywithconfig.md
+++ b/docs/data/core-sharereplaywithconfig.md
@@ -1,7 +1,7 @@
 ---
 name: ShareReplayWithConfig
 slug: sharereplaywithconfig
-sourceRef: operator_connectable.go#L220
+sourceRef: operator_connectable.go#L224
 type: core
 category: connectable
 signatures:

--- a/docs/data/core-sharewithconfig.md
+++ b/docs/data/core-sharewithconfig.md
@@ -1,7 +1,7 @@
 ---
 name: ShareWithConfig
 slug: sharewithconfig
-sourceRef: operator_connectable.go#L64
+sourceRef: operator_connectable.go#L67
 type: core
 category: connectable
 signatures:

--- a/docs/data/core-skip.md
+++ b/docs/data/core-skip.md
@@ -1,7 +1,7 @@
 ---
 name: Skip
 slug: skip
-sourceRef: operator_filter.go#L122
+sourceRef: operator_filter.go#L165
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-skiplast.md
+++ b/docs/data/core-skiplast.md
@@ -1,7 +1,7 @@
 ---
 name: SkipLast
 slug: skiplast
-sourceRef: operator_filter.go#L262
+sourceRef: operator_filter.go#L263
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-skipuntil.md
+++ b/docs/data/core-skipuntil.md
@@ -1,7 +1,7 @@
 ---
 name: SkipUntil
 slug: skipuntil
-sourceRef: operator_filter.go#L302
+sourceRef: operator_filter.go#L304
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-skipwhile.md
+++ b/docs/data/core-skipwhile.md
@@ -1,7 +1,7 @@
 ---
 name: SkipWhile
 slug: skipwhile
-sourceRef: operator_filter.go#L155
+sourceRef: operator_filter.go#L198
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-start.md
+++ b/docs/data/core-start.md
@@ -1,7 +1,7 @@
 ---
 name: Start
 slug: start
-sourceRef: operator_creation.go#L66
+sourceRef: operator_creation.go#L48
 type: core
 category: creation
 signatures:

--- a/docs/data/core-startwith.md
+++ b/docs/data/core-startwith.md
@@ -1,7 +1,7 @@
 ---
 name: StartWith
 slug: startwith
-sourceRef: operator_combining.go#L906
+sourceRef: operator_combining.go#L933
 type: core
 category: combining
 signatures:

--- a/docs/data/core-subscribeon.md
+++ b/docs/data/core-subscribeon.md
@@ -1,7 +1,7 @@
 ---
 name: SubscribeOn
 slug: subscribeon
-sourceRef: scheduler.go#L59
+sourceRef: operator_utility.go#L546
 type: core
 category: utility
 signatures:

--- a/docs/data/core-sum.md
+++ b/docs/data/core-sum.md
@@ -1,7 +1,7 @@
 ---
 name: Sum
 slug: sum
-sourceRef: operator_math.go#L86
+sourceRef: operator_math.go#L107
 type: core
 category: math
 signatures:

--- a/docs/data/core-tail.md
+++ b/docs/data/core-tail.md
@@ -1,7 +1,7 @@
 ---
 name: Tail
 slug: tail
-sourceRef: operator_filter.go#L533
+sourceRef: operator_filter.go#L586
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-take.md
+++ b/docs/data/core-take.md
@@ -1,7 +1,7 @@
 ---
 name: Take
 slug: take
-sourceRef: operator_filter.go#L299
+sourceRef: operator_filter.go#L346
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-takelast.md
+++ b/docs/data/core-takelast.md
@@ -1,7 +1,7 @@
 ---
 name: TakeLast
 slug: takelast
-sourceRef: operator_filter.go#L414
+sourceRef: operator_filter.go#L463
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-takeuntil.md
+++ b/docs/data/core-takeuntil.md
@@ -1,7 +1,7 @@
 ---
 name: TakeUntil
 slug: takeuntil
-sourceRef: operator_filter.go#L516
+sourceRef: operator_filter.go#L518
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-takewhile.md
+++ b/docs/data/core-takewhile.md
@@ -1,7 +1,7 @@
 ---
 name: TakeWhile
 slug: takewhile
-sourceRef: operator_filter.go#L339
+sourceRef: operator_filter.go#L387
 type: core
 category: filtering
 signatures:

--- a/docs/data/core-tap.md
+++ b/docs/data/core-tap.md
@@ -1,7 +1,7 @@
 ---
 name: Tap
 slug: tap
-sourceRef: operator_utility.go#L30
+sourceRef: operator_utility.go#L32
 type: core
 category: utility
 signatures:

--- a/docs/data/core-throw.md
+++ b/docs/data/core-throw.md
@@ -1,7 +1,7 @@
 ---
 name: Throw
 slug: throw
-sourceRef: operator_creation.go#L46
+sourceRef: operator_creation.go#L425
 type: core
 category: creation
 signatures:

--- a/docs/data/core-throwifempty.md
+++ b/docs/data/core-throwifempty.md
@@ -1,7 +1,7 @@
 ---
 name: ThrowIfEmpty
 slug: throwifempty
-sourceRef: operator_error_handling.go#L229
+sourceRef: operator_error_handling.go#L227
 type: core
 category: error-handling
 signatures:

--- a/docs/data/core-throwoncontextcancel.md
+++ b/docs/data/core-throwoncontextcancel.md
@@ -1,7 +1,7 @@
 ---
 name: ThrowOnContextCancel
 slug: throwoncontextcancel
-sourceRef: operator_context.go#L196
+sourceRef: operator_context.go#L255
 type: core
 category: context
 signatures:

--- a/docs/data/core-timeinterval.md
+++ b/docs/data/core-timeinterval.md
@@ -1,7 +1,7 @@
 ---
 name: TimeInterval
 slug: timeinterval
-sourceRef: operator_utility.go#L245
+sourceRef: operator_utility.go#L229
 type: core
 category: utility
 signatures:

--- a/docs/data/core-timeout.md
+++ b/docs/data/core-timeout.md
@@ -1,7 +1,7 @@
 ---
 name: Timeout
 slug: timeout
-sourceRef: operator_utility.go#L419
+sourceRef: operator_utility.go#L437
 type: core
 category: utility
 signatures:

--- a/docs/data/core-timer.md
+++ b/docs/data/core-timer.md
@@ -1,7 +1,7 @@
 ---
 name: Timer
 slug: timer
-sourceRef: operator_creation.go#L95
+sourceRef: operator_creation.go#L59
 type: core
 category: creation
 signatures:

--- a/docs/data/core-timestamp.md
+++ b/docs/data/core-timestamp.md
@@ -1,7 +1,7 @@
 ---
 name: Timestamp
 slug: timestamp
-sourceRef: operator_utility.go#L258
+sourceRef: operator_utility.go#L263
 type: core
 category: utility
 signatures:

--- a/docs/data/core-tochannel.md
+++ b/docs/data/core-tochannel.md
@@ -1,7 +1,7 @@
 ---
 name: ToChannel
 slug: tochannel
-sourceRef: operator_sink.go#L120
+sourceRef: operator_sink.go#L118
 type: core
 category: sink
 signatures:

--- a/docs/data/core-tomap.md
+++ b/docs/data/core-tomap.md
@@ -1,7 +1,7 @@
 ---
 name: ToMap
 slug: tomap
-sourceRef: operator_sink.go#L60
+sourceRef: operator_sink.go#L55
 type: core
 category: sink
 signatures:

--- a/docs/data/core-toslice.md
+++ b/docs/data/core-toslice.md
@@ -1,7 +1,7 @@
 ---
 name: ToSlice
 slug: toslice
-sourceRef: operator_sink.go#L30
+sourceRef: operator_sink.go#L27
 type: core
 category: sink
 signatures:

--- a/docs/data/core-while.md
+++ b/docs/data/core-while.md
@@ -1,7 +1,7 @@
 ---
 name: While
 slug: while
-sourceRef: operator_error_handling.go#L349
+sourceRef: operator_error_handling.go#L351
 type: core
 category: error-handling
 signatures:

--- a/docs/data/core-windowwhen.md
+++ b/docs/data/core-windowwhen.md
@@ -1,7 +1,7 @@
 ---
 name: WindowWhen
 slug: windowwhen
-sourceRef: operator_transformations.go#L593
+sourceRef: operator_transformations.go#L617
 type: core
 category: transformation
 signatures:

--- a/docs/data/core-zip.md
+++ b/docs/data/core-zip.md
@@ -1,7 +1,7 @@
 ---
 name: Zip
 slug: zip
-sourceRef: operator_creation.go#L473
+sourceRef: operator_creation.go#L523
 type: core
 category: combining
 signatures:

--- a/docs/data/core-zipall.md
+++ b/docs/data/core-zipall.md
@@ -1,7 +1,7 @@
 ---
 name: ZipAll
 slug: zipall
-sourceRef: operator_combining.go#L83
+sourceRef: operator_combining.go#L1590
 type: core
 category: combining
 signatures:

--- a/docs/data/core-zipwith.md
+++ b/docs/data/core-zipwith.md
@@ -1,7 +1,7 @@
 ---
 name: ZipWith
 slug: zipwith
-sourceRef: operator_creation.go#L479
+sourceRef: operator_combining.go#L1151
 type: core
 category: combining
 signatures:

--- a/docs/data/plugin-bytes-camelcase.md
+++ b/docs/data/plugin-bytes-camelcase.md
@@ -1,7 +1,7 @@
 ---
 name: CamelCase
 slug: camelcase
-sourceRef: plugins/bytes/operator_camelcase.go#L37
+sourceRef: plugins/bytes/operator_camelcase.go#L54
 type: plugin
 category: bytes
 signatures:

--- a/docs/data/plugin-bytes-capitalize.md
+++ b/docs/data/plugin-bytes-capitalize.md
@@ -1,7 +1,7 @@
 ---
 name: Capitalize
 slug: capitalize
-sourceRef: plugins/bytes/operator_capitalize.go#L29
+sourceRef: plugins/bytes/operator_capitalize.go#L82
 type: plugin
 category: bytes
 signatures:

--- a/docs/data/plugin-bytes-ellipsis.md
+++ b/docs/data/plugin-bytes-ellipsis.md
@@ -1,7 +1,7 @@
 ---
 name: Ellipsis
 slug: ellipsis
-sourceRef: plugins/bytes/operator_ellipsis.go#L38
+sourceRef: plugins/bytes/operator_ellipsis.go#L47
 type: plugin
 category: bytes
 signatures:

--- a/docs/data/plugin-bytes-kebabcase.md
+++ b/docs/data/plugin-bytes-kebabcase.md
@@ -1,7 +1,7 @@
 ---
 name: KebabCase
 slug: kebabcase
-sourceRef: plugins/bytes/operator_kebabcase.go#L58
+sourceRef: plugins/bytes/operator_kebabcase.go#L47
 type: plugin
 category: bytes
 signatures:

--- a/docs/data/plugin-bytes-pascalcase.md
+++ b/docs/data/plugin-bytes-pascalcase.md
@@ -1,7 +1,7 @@
 ---
 name: PascalCase
 slug: pascalcase
-sourceRef: plugins/bytes/operator_pascalcase.go#L33
+sourceRef: plugins/bytes/operator_pascalcase.go#L47
 type: plugin
 category: bytes
 signatures:

--- a/docs/data/plugin-bytes-random.md
+++ b/docs/data/plugin-bytes-random.md
@@ -1,7 +1,7 @@
 ---
 name: Random
 slug: random
-sourceRef: plugins/bytes/operator_random.go#L89
+sourceRef: plugins/bytes/operator_random.go#L98
 type: plugin
 category: bytes
 signatures:

--- a/docs/data/plugin-bytes-snakecase.md
+++ b/docs/data/plugin-bytes-snakecase.md
@@ -1,7 +1,7 @@
 ---
 name: SnakeCase
 slug: snakecase
-sourceRef: plugins/bytes/operator_snakecase.go#L33
+sourceRef: plugins/bytes/operator_snakecase.go#L47
 type: plugin
 category: bytes
 signatures:

--- a/docs/data/plugin-bytes-words.md
+++ b/docs/data/plugin-bytes-words.md
@@ -1,7 +1,7 @@
 ---
 name: Words
 slug: words
-sourceRef: plugins/bytes/operator_words.go#L41
+sourceRef: plugins/bytes/operator_words.go#L42
 type: plugin
 category: bytes
 signatures:

--- a/docs/data/plugin-encoding-base64-decode.md
+++ b/docs/data/plugin-encoding-base64-decode.md
@@ -1,7 +1,7 @@
 ---
 name: Decode
 slug: decode
-sourceRef: plugins/encoding/base64/operator.go#L46
+sourceRef: plugins/encoding/base64/operator.go#L48
 type: plugin
 category: encoding-base64
 signatures:

--- a/docs/data/plugin-encoding-base64-encode.md
+++ b/docs/data/plugin-encoding-base64-encode.md
@@ -1,7 +1,7 @@
 ---
 name: Encode
 slug: encode
-sourceRef: plugins/encoding/base64/operator.go#L32
+sourceRef: plugins/encoding/base64/operator.go#L33
 type: plugin
 category: encoding-base64
 signatures:

--- a/docs/data/plugin-encoding-csv-newcsvreader.md
+++ b/docs/data/plugin-encoding-csv-newcsvreader.md
@@ -1,7 +1,7 @@
 ---
 name: NewCSVReader
 slug: newcsvreader
-sourceRef: plugins/encoding/csv/source.go#L26
+sourceRef: plugins/encoding/csv/source.go#L28
 type: plugin
 category: encoding-csv
 signatures:

--- a/docs/data/plugin-encoding-csv-newcsvwriter.md
+++ b/docs/data/plugin-encoding-csv-newcsvwriter.md
@@ -1,7 +1,7 @@
 ---
 name: NewCSVWriter
 slug: newcsvwriter
-sourceRef: plugins/encoding/csv/sink.go#L25
+sourceRef: plugins/encoding/csv/sink.go#L27
 type: plugin
 category: encoding-csv
 signatures:

--- a/docs/data/plugin-encoding-gob-decode.md
+++ b/docs/data/plugin-encoding-gob-decode.md
@@ -1,7 +1,7 @@
 ---
 name: Decode
 slug: decode
-sourceRef: plugins/encoding/gob/operator.go#L33
+sourceRef: plugins/encoding/gob/operator.go#L37
 type: plugin
 category: encoding-gob
 signatures:

--- a/docs/data/plugin-encoding-gob-encode.md
+++ b/docs/data/plugin-encoding-gob-encode.md
@@ -1,7 +1,7 @@
 ---
 name: Encode
 slug: encode
-sourceRef: plugins/encoding/gob/operator.go#L25
+sourceRef: plugins/encoding/gob/operator.go#L27
 type: plugin
 category: encoding-gob
 signatures:

--- a/docs/data/plugin-encoding-json-marshal.md
+++ b/docs/data/plugin-encoding-json-marshal.md
@@ -1,7 +1,7 @@
 ---
 name: Marshal
 slug: marshal
-sourceRef: plugins/encoding/json/operator.go#L24
+sourceRef: plugins/encoding/json/operator.go#L26
 type: plugin
 category: encoding-json
 signatures:

--- a/docs/data/plugin-encoding-json-unmarshal.md
+++ b/docs/data/plugin-encoding-json-unmarshal.md
@@ -1,7 +1,7 @@
 ---
 name: Unmarshal
 slug: unmarshal
-sourceRef: plugins/encoding/json/operator.go#L30
+sourceRef: plugins/encoding/json/operator.go#L34
 type: plugin
 category: encoding-json
 signatures:

--- a/docs/data/plugin-encoding-json-v2-unmarshal.md
+++ b/docs/data/plugin-encoding-json-v2-unmarshal.md
@@ -1,7 +1,7 @@
 ---
 name: Unmarshal
 slug: unmarshal
-sourceRef: plugins/encoding/json/v2/operator.go#L31
+sourceRef: plugins/encoding/json/v2/operator.go#L33
 type: plugin
 category: encoding-json-v2
 signatures:

--- a/docs/data/plugin-http-client-httprequest.md
+++ b/docs/data/plugin-http-client-httprequest.md
@@ -1,7 +1,7 @@
 ---
 name: HTTPRequest
 slug: httprequest
-sourceRef: plugins/http/client/source.go#L31
+sourceRef: plugins/http/client/source.go#L30
 type: plugin
 category: http-client
 signatures:

--- a/docs/data/plugin-http-client-httprequestjson.md
+++ b/docs/data/plugin-http-client-httprequestjson.md
@@ -1,7 +1,7 @@
 ---
 name: HTTPRequestJSON
 slug: httprequestjson
-sourceRef: plugins/http/client/source.go#L56
+sourceRef: plugins/http/client/source.go#L55
 type: plugin
 category: http-client
 signatures:

--- a/docs/data/plugin-hyperloglog-countdistinct.md
+++ b/docs/data/plugin-hyperloglog-countdistinct.md
@@ -1,7 +1,7 @@
 ---
 name: CountDistinct
 slug: countdistinct
-sourceRef: plugins/hyperloglog/operator.go#L28
+sourceRef: plugins/hyperloglog/operator.go#L25
 type: plugin
 category: hyperloglog
 signatures:

--- a/docs/data/plugin-hyperloglog-countdistinctreduce.md
+++ b/docs/data/plugin-hyperloglog-countdistinctreduce.md
@@ -1,7 +1,7 @@
 ---
 name: CountDistinctReduce
 slug: countdistinctreduce
-sourceRef: plugins/hyperloglog/operator.go#L57
+sourceRef: plugins/hyperloglog/operator.go#L54
 type: plugin
 category: hyperloglog
 signatures:

--- a/docs/data/plugin-ics-newicsfilereader.md
+++ b/docs/data/plugin-ics-newicsfilereader.md
@@ -1,7 +1,7 @@
 ---
 name: NewICSFileReader
 slug: newicsfilereader
-sourceRef: source.go#L27
+sourceRef: plugins/ics/source.go#L27
 type: plugin
 category: ics
 signatures:

--- a/docs/data/plugin-ics-newicsurlreader.md
+++ b/docs/data/plugin-ics-newicsurlreader.md
@@ -1,7 +1,7 @@
 ---
 name: NewICSURLReader
 slug: newicsurlreader
-sourceRef: source.go#L56
+sourceRef: plugins/ics/source.go#L56
 type: plugin
 category: ics
 signatures:

--- a/docs/data/plugin-iter-fromseq.md
+++ b/docs/data/plugin-iter-fromseq.md
@@ -1,7 +1,7 @@
 ---
 name: FromSeq
 slug: fromseq
-sourceRef: plugins/iter/source.go#L26
+sourceRef: plugins/iter/source.go#L28
 type: plugin
 category: iter
 signatures:

--- a/docs/data/plugin-iter-fromseq2.md
+++ b/docs/data/plugin-iter-fromseq2.md
@@ -1,7 +1,7 @@
 ---
 name: FromSeq2
 slug: fromseq2
-sourceRef: plugins/iter/source.go#L36
+sourceRef: plugins/iter/source.go#L40
 type: plugin
 category: iter
 signatures:

--- a/docs/data/plugin-iter-toseq.md
+++ b/docs/data/plugin-iter-toseq.md
@@ -1,7 +1,7 @@
 ---
 name: ToSeq
 slug: toseq
-sourceRef: plugins/iter/sink.go#L24
+sourceRef: plugins/iter/sink.go#L25
 type: plugin
 category: iter
 signatures:

--- a/docs/data/plugin-iter-toseq2.md
+++ b/docs/data/plugin-iter-toseq2.md
@@ -1,7 +1,7 @@
 ---
 name: ToSeq2
 slug: toseq2
-sourceRef: plugins/iter/sink.go#L71
+sourceRef: plugins/iter/sink.go#L74
 type: plugin
 category: iter
 signatures:

--- a/docs/data/plugin-logger-log-fatalonerror.md
+++ b/docs/data/plugin-logger-log-fatalonerror.md
@@ -1,7 +1,7 @@
 ---
 name: FatalOnError
 slug: fatalonerror
-sourceRef: plugins/observability/log/operator.go#L47
+sourceRef: plugins/observability/log/operator.go#L51
 type: plugin
 category: logger-log
 signatures:

--- a/docs/data/plugin-logger-log-fatalonerrorwithprefix.md
+++ b/docs/data/plugin-logger-log-fatalonerrorwithprefix.md
@@ -1,7 +1,7 @@
 ---
 name: FatalOnErrorWithPrefix
 slug: fatalonerrorwithprefix
-sourceRef: plugins/observability/log/operator.go#L59
+sourceRef: plugins/observability/log/operator.go#L56
 type: plugin
 category: logger-log
 signatures:

--- a/docs/data/plugin-logger-log-log.md
+++ b/docs/data/plugin-logger-log-log.md
@@ -1,7 +1,7 @@
 ---
 name: Log
 slug: log
-sourceRef: plugins/observability/log/operator.go#L25
+sourceRef: plugins/observability/log/operator.go#L24
 type: plugin
 category: logger-log
 signatures:

--- a/docs/data/plugin-logger-log-logwithprefix.md
+++ b/docs/data/plugin-logger-log-logwithprefix.md
@@ -1,7 +1,7 @@
 ---
 name: LogWithPrefix
 slug: logwithprefix
-sourceRef: plugins/observability/log/operator.go#L31
+sourceRef: plugins/observability/log/operator.go#L29
 type: plugin
 category: logger-log
 signatures:

--- a/docs/data/plugin-logger-logrus-fatalonerror.md
+++ b/docs/data/plugin-logger-logrus-fatalonerror.md
@@ -1,7 +1,7 @@
 ---
 name: FatalOnError
 slug: fatalonerror
-sourceRef: plugins/observability/logrus/operator.go#L53
+sourceRef: plugins/observability/logrus/operator.go#L59
 type: plugin
 category: logger-logrus
 signatures:

--- a/docs/data/plugin-logger-logrus-log.md
+++ b/docs/data/plugin-logger-logrus-log.md
@@ -1,7 +1,7 @@
 ---
 name: Log
 slug: log
-sourceRef: plugins/observability/logrus/operator.go#L25
+sourceRef: plugins/observability/logrus/operator.go#L27
 type: plugin
 category: logger-logrus
 signatures:

--- a/docs/data/plugin-logger-logrus-logwithnotification.md
+++ b/docs/data/plugin-logger-logrus-logwithnotification.md
@@ -1,7 +1,7 @@
 ---
 name: LogWithNotification
 slug: logwithnotification
-sourceRef: plugins/observability/logrus/operator.go#L39
+sourceRef: plugins/observability/logrus/operator.go#L43
 type: plugin
 category: logger-logrus
 signatures:

--- a/docs/data/plugin-logger-zap-fatalonerror.md
+++ b/docs/data/plugin-logger-zap-fatalonerror.md
@@ -1,7 +1,7 @@
 ---
 name: FatalOnError
 slug: fatalonerror
-sourceRef: plugins/observability/zap/operator.go#L55
+sourceRef: plugins/observability/zap/operator.go#L61
 type: plugin
 category: logger-zap
 signatures:

--- a/docs/data/plugin-logger-zap-log.md
+++ b/docs/data/plugin-logger-zap-log.md
@@ -1,7 +1,7 @@
 ---
 name: Log
 slug: log
-sourceRef: plugins/observability/zap/operator.go#L27
+sourceRef: plugins/observability/zap/operator.go#L29
 type: plugin
 category: logger-zap
 signatures:

--- a/docs/data/plugin-logger-zap-logwithnotification.md
+++ b/docs/data/plugin-logger-zap-logwithnotification.md
@@ -1,7 +1,7 @@
 ---
 name: LogWithNotification
 slug: logwithnotification
-sourceRef: plugins/observability/zap/operator.go#L41
+sourceRef: plugins/observability/zap/operator.go#L45
 type: plugin
 category: logger-zap
 signatures:

--- a/docs/data/plugin-logger-zerolog-fatalonerror.md
+++ b/docs/data/plugin-logger-zerolog-fatalonerror.md
@@ -1,7 +1,7 @@
 ---
 name: FatalOnError
 slug: fatalonerror
-sourceRef: plugins/observability/zerolog/operator.go#L53
+sourceRef: plugins/observability/zerolog/operator.go#L59
 type: plugin
 category: logger-zerolog
 signatures:

--- a/docs/data/plugin-logger-zerolog-log.md
+++ b/docs/data/plugin-logger-zerolog-log.md
@@ -1,7 +1,7 @@
 ---
 name: Log
 slug: log
-sourceRef: plugins/observability/zerolog/operator.go#L25
+sourceRef: plugins/observability/zerolog/operator.go#L27
 type: plugin
 category: logger-zerolog
 signatures:

--- a/docs/data/plugin-logger-zerolog-logwithnotification.md
+++ b/docs/data/plugin-logger-zerolog-logwithnotification.md
@@ -1,7 +1,7 @@
 ---
 name: LogWithNotification
 slug: logwithnotification
-sourceRef: plugins/observability/zerolog/operator.go#L39
+sourceRef: plugins/observability/zerolog/operator.go#L43
 type: plugin
 category: logger-zerolog
 signatures:

--- a/docs/data/plugin-observability-slog-log.md
+++ b/docs/data/plugin-observability-slog-log.md
@@ -1,7 +1,7 @@
 ---
 name: Log
 slug: log
-sourceRef: plugins/observability/slog/operator.go#L26
+sourceRef: plugins/observability/slog/operator.go#L28
 type: plugin
 category: logger-slog
 signatures:

--- a/docs/data/plugin-observability-slog-logwithnotification.md
+++ b/docs/data/plugin-observability-slog-logwithnotification.md
@@ -1,7 +1,7 @@
 ---
 name: LogWithNotification
 slug: logwithnotification
-sourceRef: plugins/observability/slog/operator.go#L40
+sourceRef: plugins/observability/slog/operator.go#L44
 type: plugin
 category: logger-slog
 signatures:

--- a/docs/data/plugin-ozzo-validation-validate.md
+++ b/docs/data/plugin-ozzo-validation-validate.md
@@ -1,7 +1,7 @@
 ---
 name: Validate
 slug: validate
-sourceRef: plugins/ozzo/operator.go#L32
+sourceRef: plugins/ozzo/ozzo-validation/operator.go#L34
 type: plugin
 category: ozzo-validation
 signatures:

--- a/docs/data/plugin-ozzo-validation-validateorerror.md
+++ b/docs/data/plugin-ozzo-validation-validateorerror.md
@@ -1,7 +1,7 @@
 ---
 name: ValidateOrError
 slug: validateorerror
-sourceRef: plugins/ozzo/operator.go#L82
+sourceRef: plugins/ozzo/ozzo-validation/operator.go#L92
 type: plugin
 category: ozzo-validation
 signatures:

--- a/docs/data/plugin-ozzo-validation-validateorerrorwithcontext.md
+++ b/docs/data/plugin-ozzo-validation-validateorerrorwithcontext.md
@@ -1,7 +1,7 @@
 ---
 name: ValidateOrErrorWithContext
 slug: validateorerrorwithcontext
-sourceRef: plugins/ozzo/ozzo-validation/operator.go#L101
+sourceRef: plugins/ozzo/ozzo-validation/operator.go#L115
 type: plugin
 category: ozzo-validation
 signatures:

--- a/docs/data/plugin-ozzo-validation-validateorskip.md
+++ b/docs/data/plugin-ozzo-validation-validateorskip.md
@@ -1,7 +1,7 @@
 ---
 name: ValidateOrSkip
 slug: validateorskip
-sourceRef: plugins/ozzo/operator.go#L115
+sourceRef: plugins/ozzo/ozzo-validation/operator.go#L138
 type: plugin
 category: ozzo-validation
 signatures:

--- a/docs/data/plugin-ozzo-validation-validateorskipwithcontext.md
+++ b/docs/data/plugin-ozzo-validation-validateorskipwithcontext.md
@@ -1,7 +1,7 @@
 ---
 name: ValidateOrSkipWithContext
 slug: validateorskipwithcontext
-sourceRef: plugins/ozzo/operator.go#L131
+sourceRef: plugins/ozzo/ozzo-validation/operator.go#L161
 type: plugin
 category: ozzo-validation
 signatures:

--- a/docs/data/plugin-ozzo-validation-validatestruct.md
+++ b/docs/data/plugin-ozzo-validation-validatestruct.md
@@ -1,7 +1,7 @@
 ---
 name: ValidateStruct
 slug: validatestruct
-sourceRef: plugins/ozzo/ozzo-validation/operator.go#L42
+sourceRef: plugins/ozzo/ozzo-validation/operator.go#L46
 type: plugin
 category: ozzo-validation
 signatures:

--- a/docs/data/plugin-ozzo-validation-validatestructorerror.md
+++ b/docs/data/plugin-ozzo-validation-validatestructorerror.md
@@ -1,7 +1,7 @@
 ---
 name: ValidateStructOrError
 slug: validatestructorerror
-sourceRef: plugins/ozzo/ozzo-validation/operator.go#L89
+sourceRef: plugins/ozzo/ozzo-validation/operator.go#L101
 type: plugin
 category: ozzo-validation
 signatures:

--- a/docs/data/plugin-ozzo-validation-validatestructorerrorwithcontext.md
+++ b/docs/data/plugin-ozzo-validation-validatestructorerrorwithcontext.md
@@ -1,7 +1,7 @@
 ---
 name: ValidateStructOrErrorWithContext
 slug: validatestructorerrorwithcontext
-sourceRef: plugins/ozzo/ozzo-validation/operator.go#L108
+sourceRef: plugins/ozzo/ozzo-validation/operator.go#L124
 type: plugin
 category: ozzo-validation
 signatures:

--- a/docs/data/plugin-ozzo-validation-validatestructorskip.md
+++ b/docs/data/plugin-ozzo-validation-validatestructorskip.md
@@ -1,7 +1,7 @@
 ---
 name: ValidateStructOrSkip
 slug: validatestructorskip
-sourceRef: plugins/ozzo/operator.go#L123
+sourceRef: plugins/ozzo/ozzo-validation/operator.go#L147
 type: plugin
 category: ozzo-validation
 signatures:

--- a/docs/data/plugin-ozzo-validation-validatestructorskipwithcontext.md
+++ b/docs/data/plugin-ozzo-validation-validatestructorskipwithcontext.md
@@ -1,7 +1,7 @@
 ---
 name: ValidateStructOrSkipWithContext
 slug: validatestructorskipwithcontext
-sourceRef: plugins/ozzo/operator.go#L139
+sourceRef: plugins/ozzo/ozzo-validation/operator.go#L170
 type: plugin
 category: ozzo-validation
 signatures:

--- a/docs/data/plugin-ozzo-validation-validatestructwithcontext.md
+++ b/docs/data/plugin-ozzo-validation-validatestructwithcontext.md
@@ -1,7 +1,7 @@
 ---
 name: ValidateStructWithContext
 slug: validatestructwithcontext
-sourceRef: plugins/ozzo/ozzo-validation/operator.go#L67
+sourceRef: plugins/ozzo/ozzo-validation/operator.go#L75
 type: plugin
 category: ozzo-validation
 signatures:

--- a/docs/data/plugin-ozzo-validation-validatewithcontext.md
+++ b/docs/data/plugin-ozzo-validation-validatewithcontext.md
@@ -1,7 +1,7 @@
 ---
 name: ValidateWithContext
 slug: validatewithcontext
-sourceRef: plugins/ozzo/ozzo-validation/operator.go#L57
+sourceRef: plugins/ozzo/ozzo-validation/operator.go#L63
 type: plugin
 category: ozzo-validation
 signatures:

--- a/docs/data/plugin-proc-newcpuinfowatcher.md
+++ b/docs/data/plugin-proc-newcpuinfowatcher.md
@@ -1,7 +1,7 @@
 ---
 name: NewCPUInfoWatcher
 slug: newcpuinfowatcher
-sourceRef: plugins/proc/source.go#L105
+sourceRef: plugins/proc/source.go#L109
 type: plugin
 category: proc
 signatures:

--- a/docs/data/plugin-proc-newdiskiocounterswatcher.md
+++ b/docs/data/plugin-proc-newdiskiocounterswatcher.md
@@ -1,7 +1,7 @@
 ---
 name: NewDiskIOCountersWatcher
 slug: newdiskiocounterswatcher
-sourceRef: plugins/proc/source.go#L153
+sourceRef: plugins/proc/source.go#L161
 type: plugin
 category: proc
 signatures:

--- a/docs/data/plugin-proc-newdiskpartitionwatcher.md
+++ b/docs/data/plugin-proc-newdiskpartitionwatcher.md
@@ -1,7 +1,7 @@
 ---
 name: NewDiskPartitionWatcher
 slug: newdiskpartitionwatcher
-sourceRef: plugins/proc/source.go#L175
+sourceRef: plugins/proc/source.go#L186
 type: plugin
 category: proc
 signatures:

--- a/docs/data/plugin-proc-newdiskusagewatcher.md
+++ b/docs/data/plugin-proc-newdiskusagewatcher.md
@@ -1,7 +1,7 @@
 ---
 name: NewDiskUsageWatcher
 slug: newdiskusagewatcher
-sourceRef: plugins/proc/source.go#L131
+sourceRef: plugins/proc/source.go#L136
 type: plugin
 category: proc
 signatures:

--- a/docs/data/plugin-proc-newhostinfowatcher.md
+++ b/docs/data/plugin-proc-newhostinfowatcher.md
@@ -1,7 +1,7 @@
 ---
 name: NewHostInfoWatcher
 slug: newhostinfowatcher
-sourceRef: plugins/proc/source.go#L205
+sourceRef: plugins/proc/source.go#L213
 type: plugin
 category: proc
 signatures:

--- a/docs/data/plugin-proc-newhostuserwatcher.md
+++ b/docs/data/plugin-proc-newhostuserwatcher.md
@@ -1,7 +1,7 @@
 ---
 name: NewHostUserWatcher
 slug: newhostuserwatcher
-sourceRef: plugins/proc/source.go#L219
+sourceRef: plugins/proc/source.go#L238
 type: plugin
 category: proc
 signatures:

--- a/docs/data/plugin-proc-newloadaveragewatcher.md
+++ b/docs/data/plugin-proc-newloadaveragewatcher.md
@@ -1,7 +1,7 @@
 ---
 name: NewLoadAverageWatcher
 slug: newloadaveragewatcher
-sourceRef: plugins/proc/source.go#L255
+sourceRef: plugins/proc/source.go#L265
 type: plugin
 category: proc
 signatures:

--- a/docs/data/plugin-proc-newloadmiscwatcher.md
+++ b/docs/data/plugin-proc-newloadmiscwatcher.md
@@ -1,7 +1,7 @@
 ---
 name: NewLoadMiscWatcher
 slug: newloadmiscwatcher
-sourceRef: plugins/proc/source.go#L263
+sourceRef: plugins/proc/source.go#L290
 type: plugin
 category: proc
 signatures:

--- a/docs/data/plugin-proc-newnetconnectionswatcher.md
+++ b/docs/data/plugin-proc-newnetconnectionswatcher.md
@@ -1,7 +1,7 @@
 ---
 name: NewNetConnectionsWatcher
 slug: newnetconnectionswatcher
-sourceRef: plugins/proc/source.go#L285
+sourceRef: plugins/proc/source.go#L315
 type: plugin
 category: proc
 signatures:

--- a/docs/data/plugin-proc-newnetconntrackwatcher.md
+++ b/docs/data/plugin-proc-newnetconntrackwatcher.md
@@ -1,7 +1,7 @@
 ---
 name: NewNetConntrackWatcher
 slug: newnetconntrackwatcher
-sourceRef: plugins/proc/source.go#L307
+sourceRef: plugins/proc/source.go#L342
 type: plugin
 category: proc
 signatures:

--- a/docs/data/plugin-proc-newnetfiltercounterswatcher.md
+++ b/docs/data/plugin-proc-newnetfiltercounterswatcher.md
@@ -1,7 +1,7 @@
 ---
 name: NewNetFilterCountersWatcher
 slug: newnetfiltercounterswatcher
-sourceRef: plugins/proc/source.go#L329
+sourceRef: plugins/proc/source.go#L369
 type: plugin
 category: proc
 signatures:

--- a/docs/data/plugin-proc-newnetiocounterswatcher.md
+++ b/docs/data/plugin-proc-newnetiocounterswatcher.md
@@ -1,7 +1,7 @@
 ---
 name: NewNetIOCountersWatcher
 slug: newnetiocounterswatcher
-sourceRef: plugins/proc/source.go#L381
+sourceRef: plugins/proc/source.go#L396
 type: plugin
 category: proc
 signatures:

--- a/docs/data/plugin-proc-newsensorstemperaturewatcher.md
+++ b/docs/data/plugin-proc-newsensorstemperaturewatcher.md
@@ -1,7 +1,7 @@
 ---
 name: NewSensorsTemperatureWatcher
 slug: newsensorstemperaturewatcher
-sourceRef: plugins/proc/source.go#L351
+sourceRef: plugins/proc/source.go#L423
 type: plugin
 category: proc
 signatures:

--- a/docs/data/plugin-proc-newswapdevicewatcher.md
+++ b/docs/data/plugin-proc-newswapdevicewatcher.md
@@ -1,7 +1,7 @@
 ---
 name: NewSwapDeviceWatcher
 slug: newswapdevicewatcher
-sourceRef: plugins/proc/source.go#L69
+sourceRef: plugins/proc/source.go#L82
 type: plugin
 category: proc
 signatures:

--- a/docs/data/plugin-proc-newswapmemorywatcher.md
+++ b/docs/data/plugin-proc-newswapmemorywatcher.md
@@ -1,7 +1,7 @@
 ---
 name: NewSwapMemoryWatcher
 slug: newswapmemorywatcher
-sourceRef: plugins/proc/source.go#L47
+sourceRef: plugins/proc/source.go#L57
 type: plugin
 category: proc
 signatures:

--- a/docs/data/plugin-proc-newvirtualmemorywatcher.md
+++ b/docs/data/plugin-proc-newvirtualmemorywatcher.md
@@ -1,7 +1,7 @@
 ---
 name: NewVirtualMemoryWatcher
 slug: newvirtualmemorywatcher
-sourceRef: plugins/proc/source.go#L25
+sourceRef: plugins/proc/source.go#L32
 type: plugin
 category: proc
 signatures:

--- a/docs/data/plugin-ratelimit-native-newratelimiter.md
+++ b/docs/data/plugin-ratelimit-native-newratelimiter.md
@@ -1,7 +1,7 @@
 ---
 name: NewRateLimiter
 slug: newratelimiter
-sourceRef: plugins/ratelimit/native/operator.go#L24
+sourceRef: plugins/ratelimit/native/operator.go#L26
 type: plugin
 category: ratelimit-native
 signatures:

--- a/docs/data/plugin-ratelimit-ulule-newratelimiter.md
+++ b/docs/data/plugin-ratelimit-ulule-newratelimiter.md
@@ -1,7 +1,7 @@
 ---
 name: NewRateLimiter
 slug: newratelimiter
-sourceRef: plugins/ratelimit/ulule/operator.go#L25
+sourceRef: plugins/ratelimit/ulule/operator.go#L27
 type: plugin
 category: ratelimit-ulule
 signatures:

--- a/docs/data/plugin-regexp-filtermatch.md
+++ b/docs/data/plugin-regexp-filtermatch.md
@@ -1,7 +1,7 @@
 ---
 name: FilterMatch
 slug: filtermatch
-sourceRef: plugins/regexp/operator.go#L109
+sourceRef: plugins/regexp/operator.go#L110
 type: plugin
 category: regexp
 signatures:

--- a/docs/data/plugin-regexp-filtermatchstring.md
+++ b/docs/data/plugin-regexp-filtermatchstring.md
@@ -1,7 +1,7 @@
 ---
 name: FilterMatchString
 slug: filtermatchstring
-sourceRef: plugins/regexp/operator.go#L115
+sourceRef: plugins/regexp/operator.go#L118
 type: plugin
 category: regexp
 signatures:

--- a/docs/data/plugin-regexp-find.md
+++ b/docs/data/plugin-regexp-find.md
@@ -1,7 +1,7 @@
 ---
 name: Find
 slug: find
-sourceRef: plugins/regexp/operator.go#L25
+sourceRef: plugins/regexp/operator.go#L26
 type: plugin
 category: regexp
 signatures:

--- a/docs/data/plugin-regexp-findall.md
+++ b/docs/data/plugin-regexp-findall.md
@@ -1,7 +1,7 @@
 ---
 name: FindAll
 slug: findall
-sourceRef: plugins/regexp/operator.go#L49
+sourceRef: plugins/regexp/operator.go#L54
 type: plugin
 category: regexp
 signatures:

--- a/docs/data/plugin-regexp-findallstring.md
+++ b/docs/data/plugin-regexp-findallstring.md
@@ -1,7 +1,7 @@
 ---
 name: FindAllString
 slug: findallstring
-sourceRef: plugins/regexp/operator.go#L56
+sourceRef: plugins/regexp/operator.go#L61
 type: plugin
 category: regexp
 signatures:

--- a/docs/data/plugin-regexp-findallstringsubmatch.md
+++ b/docs/data/plugin-regexp-findallstringsubmatch.md
@@ -1,7 +1,7 @@
 ---
 name: FindAllStringSubmatch
 slug: findallstringsubmatch
-sourceRef: plugins/regexp/operator.go#L70
+sourceRef: plugins/regexp/operator.go#L75
 type: plugin
 category: regexp
 signatures:

--- a/docs/data/plugin-regexp-findallsubmatch.md
+++ b/docs/data/plugin-regexp-findallsubmatch.md
@@ -1,7 +1,7 @@
 ---
 name: FindAllSubmatch
 slug: findallsubmatch
-sourceRef: plugins/regexp/operator.go#L63
+sourceRef: plugins/regexp/operator.go#L68
 type: plugin
 category: regexp
 signatures:

--- a/docs/data/plugin-regexp-findstring.md
+++ b/docs/data/plugin-regexp-findstring.md
@@ -1,7 +1,7 @@
 ---
 name: FindString
 slug: findstring
-sourceRef: plugins/regexp/operator.go#L32
+sourceRef: plugins/regexp/operator.go#L33
 type: plugin
 category: regexp
 signatures:

--- a/docs/data/plugin-regexp-findstringsubmatch.md
+++ b/docs/data/plugin-regexp-findstringsubmatch.md
@@ -1,7 +1,7 @@
 ---
 name: FindStringSubmatch
 slug: findstringsubmatch
-sourceRef: plugins/regexp/operator.go#L45
+sourceRef: plugins/regexp/operator.go#L47
 type: plugin
 category: regexp
 signatures:

--- a/docs/data/plugin-regexp-findsubmatch.md
+++ b/docs/data/plugin-regexp-findsubmatch.md
@@ -1,7 +1,7 @@
 ---
 name: FindSubmatch
 slug: findsubmatch
-sourceRef: plugins/regexp/operator.go#L38
+sourceRef: plugins/regexp/operator.go#L40
 type: plugin
 category: regexp
 signatures:

--- a/docs/data/plugin-regexp-match.md
+++ b/docs/data/plugin-regexp-match.md
@@ -1,7 +1,7 @@
 ---
 name: Match
 slug: match
-sourceRef: plugins/regexp/operator.go#L80
+sourceRef: plugins/regexp/operator.go#L82
 type: plugin
 category: regexp
 signatures:

--- a/docs/data/plugin-regexp-matchstring.md
+++ b/docs/data/plugin-regexp-matchstring.md
@@ -1,7 +1,7 @@
 ---
 name: MatchString
 slug: matchstring
-sourceRef: plugins/regexp/operator.go#L87
+sourceRef: plugins/regexp/operator.go#L89
 type: plugin
 category: regexp
 signatures:

--- a/docs/data/plugin-regexp-replaceall.md
+++ b/docs/data/plugin-regexp-replaceall.md
@@ -1,7 +1,7 @@
 ---
 name: ReplaceAll
 slug: replaceall
-sourceRef: plugins/regexp/operator.go#L95
+sourceRef: plugins/regexp/operator.go#L96
 type: plugin
 category: regexp
 signatures:

--- a/docs/data/plugin-regexp-replaceallstring.md
+++ b/docs/data/plugin-regexp-replaceallstring.md
@@ -1,7 +1,7 @@
 ---
 name: ReplaceAllString
 slug: replaceallstring
-sourceRef: plugins/regexp/operator.go#L101
+sourceRef: plugins/regexp/operator.go#L103
 type: plugin
 category: regexp
 signatures:

--- a/docs/data/plugin-samber-hot-getorfetch.md
+++ b/docs/data/plugin-samber-hot-getorfetch.md
@@ -1,7 +1,7 @@
 ---
 name: GetOrFetch
 slug: getorfetch
-sourceRef: plugins/samber/hot/operator_hot.go#L29
+sourceRef: plugins/samber/hot/operator_hot.go#L31
 type: plugin
 category: samber-hot
 signatures:

--- a/docs/data/plugin-samber-hot-getorfetchmany.md
+++ b/docs/data/plugin-samber-hot-getorfetchmany.md
@@ -1,7 +1,7 @@
 ---
 name: GetOrFetchMany
 slug: getorfetchmany
-sourceRef: plugins/samber/hot/operator_hot.go#L110
+sourceRef: plugins/samber/hot/operator_hot.go#L118
 type: plugin
 category: samber-hot
 signatures:

--- a/docs/data/plugin-samber-hot-getorfetchorerror.md
+++ b/docs/data/plugin-samber-hot-getorfetchorerror.md
@@ -1,7 +1,7 @@
 ---
 name: GetOrFetchOrError
 slug: getorfetchorerror
-sourceRef: plugins/samber/hot/operator_hot.go#L81
+sourceRef: plugins/samber/hot/operator_hot.go#L87
 type: plugin
 category: samber-hot
 signatures:

--- a/docs/data/plugin-samber-hot-getorfetorskip.md
+++ b/docs/data/plugin-samber-hot-getorfetorskip.md
@@ -1,7 +1,7 @@
 ---
 name: GetOrFetchOrSkip
 slug: getorfetorskip
-sourceRef: plugins/samber/hot/operator_hot.go#L54
+sourceRef: plugins/samber/hot/operator_hot.go#L58
 type: plugin
 category: samber-hot
 signatures:

--- a/docs/data/plugin-samber-psi-newpsinotifier.md
+++ b/docs/data/plugin-samber-psi-newpsinotifier.md
@@ -1,7 +1,7 @@
 ---
 name: NewPSINotifier
 slug: newpsinotifier
-sourceRef: plugins/samber/psi/source.go#L25
+sourceRef: plugins/samber/psi/source.go#L26
 type: plugin
 category: samber-psi
 signatures:

--- a/docs/data/plugin-sort-sort.md
+++ b/docs/data/plugin-sort-sort.md
@@ -1,7 +1,7 @@
 ---
 name: Sort
 slug: sort
-sourceRef: plugins/sort/operator.go#L40
+sourceRef: plugins/sort/operator.go#L41
 type: plugin
 category: sort
 signatures:

--- a/docs/data/plugin-sort-sortfunc.md
+++ b/docs/data/plugin-sort-sortfunc.md
@@ -1,7 +1,7 @@
 ---
 name: SortFunc
 slug: sortfunc
-sourceRef: plugins/sort/operator.go#L61
+sourceRef: plugins/sort/operator.go#L66
 type: plugin
 category: sort
 signatures:

--- a/docs/data/plugin-sort-sortstablefunc.md
+++ b/docs/data/plugin-sort-sortstablefunc.md
@@ -1,7 +1,7 @@
 ---
 name: SortStableFunc
 slug: sortstablefunc
-sourceRef: plugins/sort/operator.go#L82
+sourceRef: plugins/sort/operator.go#L91
 type: plugin
 category: sort
 signatures:

--- a/docs/data/plugin-stdio-newioreader.md
+++ b/docs/data/plugin-stdio-newioreader.md
@@ -1,7 +1,7 @@
 ---
 name: NewIOReader
 slug: newioreader
-sourceRef: plugins/stdio/source.go#L29
+sourceRef: plugins/stdio/source.go#L30
 type: plugin
 category: stdio
 signatures:

--- a/docs/data/plugin-stdio-newioreaderline.md
+++ b/docs/data/plugin-stdio-newioreaderline.md
@@ -1,7 +1,7 @@
 ---
 name: NewIOReaderLine
 slug: newioreaderline
-sourceRef: plugins/stdio/source.go#L54
+sourceRef: plugins/stdio/source.go#L57
 type: plugin
 category: stdio
 signatures:

--- a/docs/data/plugin-stdio-newiowriter.md
+++ b/docs/data/plugin-stdio-newiowriter.md
@@ -1,7 +1,7 @@
 ---
 name: NewIOWriter
 slug: newiowriter
-sourceRef: plugins/stdio/sink.go#L26
+sourceRef: plugins/stdio/sink.go#L27
 type: plugin
 category: stdio
 signatures:

--- a/docs/data/plugin-stdio-newprompt.md
+++ b/docs/data/plugin-stdio-newprompt.md
@@ -1,7 +1,7 @@
 ---
 name: NewPrompt
 slug: newprompt
-sourceRef: plugins/stdio/source.go#L95
+sourceRef: plugins/stdio/source.go#L98
 type: plugin
 category: stdio
 signatures:

--- a/docs/data/plugin-stdio-newstdreader.md
+++ b/docs/data/plugin-stdio-newstdreader.md
@@ -1,7 +1,7 @@
 ---
 name: NewStdReader
 slug: newstdreader
-sourceRef: plugins/stdio/source.go#L82
+sourceRef: plugins/stdio/source.go#L86
 type: plugin
 category: stdio
 signatures:

--- a/docs/data/plugin-stdio-newstdreaderline.md
+++ b/docs/data/plugin-stdio-newstdreaderline.md
@@ -1,7 +1,7 @@
 ---
 name: NewStdReaderLine
 slug: newstdreaderline
-sourceRef: plugins/stdio/source.go#L86
+sourceRef: plugins/stdio/source.go#L92
 type: plugin
 category: stdio
 signatures:

--- a/docs/data/plugin-stdio-newstdwriter.md
+++ b/docs/data/plugin-stdio-newstdwriter.md
@@ -1,7 +1,7 @@
 ---
 name: NewStdWriter
 slug: newstdwriter
-sourceRef: plugins/stdio/sink.go#L59
+sourceRef: plugins/stdio/sink.go#L62
 type: plugin
 category: stdio
 signatures:

--- a/docs/data/plugin-strconv-atoi.md
+++ b/docs/data/plugin-strconv-atoi.md
@@ -1,7 +1,7 @@
 ---
 name: Atoi
 slug: atoi
-sourceRef: plugins/strconv/operator.go#L31
+sourceRef: plugins/strconv/operator.go#L32
 type: plugin
 category: strconv
 signatures:

--- a/docs/data/plugin-strconv-formatbool.md
+++ b/docs/data/plugin-strconv-formatbool.md
@@ -1,7 +1,7 @@
 ---
 name: FormatBool
 slug: formatbool
-sourceRef: plugins/strconv/operator.go#L116
+sourceRef: plugins/strconv/operator.go#L121
 type: plugin
 category: strconv
 signatures:

--- a/docs/data/plugin-strconv-formatcomplex.md
+++ b/docs/data/plugin-strconv-formatcomplex.md
@@ -1,7 +1,7 @@
 ---
 name: FormatComplex
 slug: formatcomplex
-sourceRef: plugins/strconv/operator.go#L135
+sourceRef: plugins/strconv/operator.go#L162
 type: plugin
 category: strconv
 signatures:

--- a/docs/data/plugin-strconv-itoa.md
+++ b/docs/data/plugin-strconv-itoa.md
@@ -1,7 +1,7 @@
 ---
 name: Itoa
 slug: itoa
-sourceRef: plugins/strconv/operator.go#L194
+sourceRef: plugins/strconv/operator.go#L204
 type: plugin
 category: strconv
 signatures:

--- a/docs/data/plugin-strconv-parsebool.md
+++ b/docs/data/plugin-strconv-parsebool.md
@@ -1,7 +1,7 @@
 ---
 name: ParseBool
 slug: parsebool
-sourceRef: plugins/strconv/operator.go#L75
+sourceRef: plugins/strconv/operator.go#L79
 type: plugin
 category: strconv
 signatures:

--- a/docs/data/plugin-strconv-parsefloat.md
+++ b/docs/data/plugin-strconv-parsefloat.md
@@ -1,7 +1,7 @@
 ---
 name: ParseFloat
 slug: parsefloat
-sourceRef: plugins/strconv/operator.go#L60
+sourceRef: plugins/strconv/operator.go#L63
 type: plugin
 category: strconv
 signatures:

--- a/docs/data/plugin-strconv-parseint.md
+++ b/docs/data/plugin-strconv-parseint.md
@@ -1,7 +1,7 @@
 ---
 name: ParseInt
 slug: parseint
-sourceRef: plugins/strconv/operator.go#L46
+sourceRef: plugins/strconv/operator.go#L48
 type: plugin
 category: strconv
 signatures:

--- a/docs/data/plugin-strconv-parseuint.md
+++ b/docs/data/plugin-strconv-parseuint.md
@@ -1,7 +1,7 @@
 ---
 name: ParseUint
 slug: parseuint
-sourceRef: plugins/strconv/operator.go#L90
+sourceRef: plugins/strconv/operator.go#L94
 type: plugin
 category: strconv
 signatures:

--- a/docs/data/plugin-strconv-parseuint64.md
+++ b/docs/data/plugin-strconv-parseuint64.md
@@ -1,7 +1,7 @@
 ---
 name: ParseUint64
 slug: parseuint64
-sourceRef: plugins/strconv/operator.go#L95
+sourceRef: plugins/strconv/operator.go#L107
 type: plugin
 category: strconv
 signatures:

--- a/docs/data/plugin-strconv-quote.md
+++ b/docs/data/plugin-strconv-quote.md
@@ -1,7 +1,7 @@
 ---
 name: Quote
 slug: quote
-sourceRef: plugins/strconv/operator.go#L205
+sourceRef: plugins/strconv/operator.go#L216
 type: plugin
 category: strconv
 signatures:

--- a/docs/data/plugin-strconv-quoterune.md
+++ b/docs/data/plugin-strconv-quoterune.md
@@ -1,7 +1,7 @@
 ---
 name: QuoteRune
 slug: quoterune
-sourceRef: plugins/strconv/operator.go#L217
+sourceRef: plugins/strconv/operator.go#L228
 type: plugin
 category: strconv
 signatures:

--- a/docs/data/plugin-strconv-unquote.md
+++ b/docs/data/plugin-strconv-unquote.md
@@ -1,7 +1,7 @@
 ---
 name: Unquote
 slug: unquote
-sourceRef: plugins/strconv/operator.go#L229
+sourceRef: plugins/strconv/operator.go#L241
 type: plugin
 category: strconv
 signatures:

--- a/docs/data/plugin-strings-camelcase.md
+++ b/docs/data/plugin-strings-camelcase.md
@@ -1,7 +1,7 @@
 ---
 name: CamelCase
 slug: camelcase
-sourceRef: plugins/strings/operator_camelcase.go#L37
+sourceRef: plugins/strings/operator_camelcase.go#L54
 type: plugin
 category: strings
 signatures:

--- a/docs/data/plugin-strings-capitalize.md
+++ b/docs/data/plugin-strings-capitalize.md
@@ -1,7 +1,7 @@
 ---
 name: Capitalize
 slug: capitalize
-sourceRef: plugins/strings/operator_capitalize.go#L29
+sourceRef: plugins/strings/operator_capitalize.go#L82
 type: plugin
 category: strings
 signatures:

--- a/docs/data/plugin-strings-ellipsis.md
+++ b/docs/data/plugin-strings-ellipsis.md
@@ -1,7 +1,7 @@
 ---
 name: Ellipsis
 slug: ellipsis
-sourceRef: plugins/strings/operator_ellipsis.go#L38
+sourceRef: plugins/strings/operator_ellipsis.go#L43
 type: plugin
 category: strings
 signatures:

--- a/docs/data/plugin-strings-kebabcase.md
+++ b/docs/data/plugin-strings-kebabcase.md
@@ -1,7 +1,7 @@
 ---
 name: KebabCase
 slug: kebabcase
-sourceRef: plugins/strings/operator_kebabcase.go#L33
+sourceRef: plugins/strings/operator_kebabcase.go#L47
 type: plugin
 category: strings
 signatures:

--- a/docs/data/plugin-strings-snakecase.md
+++ b/docs/data/plugin-strings-snakecase.md
@@ -1,7 +1,7 @@
 ---
 name: SnakeCase
 slug: snakecase
-sourceRef: plugins/strings/operator_snakecase.go#L33
+sourceRef: plugins/strings/operator_snakecase.go#L47
 type: plugin
 category: strings
 signatures:

--- a/docs/data/plugin-strings-words.md
+++ b/docs/data/plugin-strings-words.md
@@ -1,7 +1,7 @@
 ---
 name: Words
 slug: words
-sourceRef: plugins/strings/operator_words.go#L41
+sourceRef: plugins/strings/operator_words.go#L42
 type: plugin
 category: strings
 signatures:

--- a/docs/data/plugin-template-htmltemplate.md
+++ b/docs/data/plugin-template-htmltemplate.md
@@ -1,7 +1,7 @@
 ---
 name: HTMLTemplate
 slug: htmltemplate
-sourceRef: plugins/template/operator.go#L36
+sourceRef: plugins/template/operator.go#L40
 type: plugin
 category: template
 signatures:

--- a/docs/data/plugin-template-texttemplate.md
+++ b/docs/data/plugin-template-texttemplate.md
@@ -1,7 +1,7 @@
 ---
 name: TextTemplate
 slug: texttemplate
-sourceRef: plugins/template/operator.go#L26
+sourceRef: plugins/template/operator.go#L28
 type: plugin
 category: template
 signatures:

--- a/docs/data/plugin-time-add.md
+++ b/docs/data/plugin-time-add.md
@@ -1,7 +1,7 @@
 ---
 name: Add
 slug: add
-sourceRef: plugins/time/operator_add.go#L33
+sourceRef: plugins/time/operator_add.go#L34
 type: plugin
 category: time
 signatures:

--- a/docs/data/plugin-time-format.md
+++ b/docs/data/plugin-time-format.md
@@ -1,7 +1,7 @@
 ---
 name: Format
 slug: format
-sourceRef: plugins/time/operator_format.go#L33
+sourceRef: plugins/time/operator_format.go#L34
 type: plugin
 category: time
 signatures:

--- a/docs/data/plugin-time-in.md
+++ b/docs/data/plugin-time-in.md
@@ -1,7 +1,7 @@
 ---
 name: In
 slug: in
-sourceRef: plugins/time/operator_in_time_zone.go#L35
+sourceRef: plugins/time/operator_in_time_zone.go#L36
 type: plugin
 category: time
 signatures:

--- a/docs/data/plugin-time-parse.md
+++ b/docs/data/plugin-time-parse.md
@@ -1,7 +1,7 @@
 ---
 name: Parse
 slug: parse
-sourceRef: plugins/time/operator_parse.go#L33
+sourceRef: plugins/time/operator_parse.go#L34
 type: plugin
 category: time
 signatures:

--- a/docs/data/plugin-time-startofday.md
+++ b/docs/data/plugin-time-startofday.md
@@ -1,7 +1,7 @@
 ---
 name: StartOfDay
 slug: startofday
-sourceRef: plugins/time/operator_start_of_day.go#L33
+sourceRef: plugins/time/operator_start_of_day.go#L34
 type: plugin
 category: time
 signatures:

--- a/docs/data/plugin-websocket-client-newwebsocketobservable.md
+++ b/docs/data/plugin-websocket-client-newwebsocketobservable.md
@@ -1,7 +1,7 @@
 ---
 name: NewWebsocketObservable
 slug: newwebsocketobservable
-sourceRef: plugins/websocket/client/observable.go#L28
+sourceRef: plugins/websocket/client/observable.go#L37
 type: plugin
 category: websocket-client
 signatures:

--- a/docs/data/plugin-websocket-client-newwebsocketobserver.md
+++ b/docs/data/plugin-websocket-client-newwebsocketobserver.md
@@ -1,7 +1,7 @@
 ---
 name: NewWebsocketObserver
 slug: newwebsocketobserver
-sourceRef: plugins/websocket/client/observer.go#L17
+sourceRef: plugins/websocket/client/observer.go#L30
 type: plugin
 category: websocket-client
 signatures:

--- a/docs/data/plugin-websocket-client-newwebsocketsubject.md
+++ b/docs/data/plugin-websocket-client-newwebsocketsubject.md
@@ -1,7 +1,7 @@
 ---
 name: NewWebsocketSubject
 slug: newwebsocketsubject
-sourceRef: plugins/websocket/client/subject.go#L67
+sourceRef: plugins/websocket/client/subject.go#L46
 type: plugin
 category: websocket-client
 signatures:


### PR DESCRIPTION
## Summary
- `docs/CLAUDE.md` now explains that `sourceRef` line numbers in `docs/data/*.md` drift whenever the referenced Go file changes, and points to `gopls symbols <file>` as the way to re-locate operators and refresh the line numbers.

## Test plan
- Docs-only change; no build/test impact.