### PR TITLE
fix(plugins/websocket): correct sentinel error package prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 cover.out
 cover.html
 .vscode
+.claude/

--- a/plugins/websocket/client/errors.go
+++ b/plugins/websocket/client/errors.go
@@ -17,7 +17,7 @@ package rowebsocketclient
 import "errors"
 
 var (
-	ErrWebsocketSubjectURLRequired           = errors.New("rowebsocket.NewWebsocketSubject: URL is required")
-	ErrWebsocketSubjectSerializerRequired    = errors.New("rowebsocket.NewWebsocketSubject: Serializer is required")
-	ErrWebsocketSubjectDeserializerRequired  = errors.New("rowebsocket.NewWebsocketSubject: Deserializer is required")
+	ErrWebsocketSubjectURLRequired          = errors.New("rowebsocketclient.NewWebsocketSubject: URL is required")
+	ErrWebsocketSubjectSerializerRequired   = errors.New("rowebsocketclient.NewWebsocketSubject: Serializer is required")
+	ErrWebsocketSubjectDeserializerRequired = errors.New("rowebsocketclient.NewWebsocketSubject: Deserializer is required")
 )


### PR DESCRIPTION
## Summary
- Fixes a Copilot review comment on #319: sentinel errors in `plugins/websocket/client/errors.go` referenced `rowebsocket.NewWebsocketSubject`, but the package is `rowebsocketclient`, breaking the `{package}.{FunctionName}: ...` convention documented in `docs/docs/contributing.md` (and used consistently by `robytes`/`rostrings`).
- Also ignores the local `.claude/` worktrees directory in `.gitignore`.

## Test plan
- [x] `cd plugins/websocket/client && go build ./... && go vet ./... && go test -race ./...` (package has no test files)
- [x] `make test` at repo root passes (2 pre-existing, unrelated `plugins/proc` failures caused by sandbox restrictions on `/var/run/utmpx` and `/bin/ps`)