### PR TITLE
feat(plugins/sort): add Reverse operator

### DIFF
--- a/docs/data/plugin-sort-reverse.md
+++ b/docs/data/plugin-sort-reverse.md
@@ -1,0 +1,60 @@
+---
+name: Reverse
+slug: reverse
+sourceRef: plugins/sort/operator.go#L126
+type: plugin
+category: sort
+signatures:
+  - "func Reverse[T any]()"
+playUrl:
+variantHelpers:
+  - plugin#sort#reverse
+similarHelpers:
+  - plugin#sort#sort
+  - core#filtering#takelast
+  - core#sink#toslice
+position: 30
+---
+
+Buffers every item emitted by the source until it completes, then re-emits them one by one in reverse order.
+
+```go
+import (
+    "github.com/samber/ro"
+    rosort "github.com/samber/ro/plugins/sort"
+)
+
+obs := ro.Pipe[int, int](
+    ro.Just(1, 2, 3, 4, 5),
+    rosort.Reverse[int](),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[int]())
+defer sub.Unsubscribe()
+
+// Next: 5
+// Next: 4
+// Next: 3
+// Next: 2
+// Next: 1
+// Completed
+```
+
+### Memory usage note
+
+```go
+// Reverse must buffer all elements before emitting the first one.
+// Never use it on an unbounded or very large source.
+obs := ro.Pipe[string, string](
+    ro.Just("apple", "banana", "cherry"),
+    rosort.Reverse[string](),
+)
+
+sub := obs.Subscribe(ro.PrintObserver[string]())
+defer sub.Unsubscribe()
+
+// Next: cherry
+// Next: banana
+// Next: apple
+// Completed
+```

--- a/docs/data/plugin-sort-reverse.md
+++ b/docs/data/plugin-sort-reverse.md
@@ -42,19 +42,4 @@ defer sub.Unsubscribe()
 
 ### Memory usage note
 
-```go
-// Reverse must buffer all elements before emitting the first one.
-// Never use it on an unbounded or very large source.
-obs := ro.Pipe[string, string](
-    ro.Just("apple", "banana", "cherry"),
-    rosort.Reverse[string](),
-)
-
-sub := obs.Subscribe(ro.PrintObserver[string]())
-defer sub.Unsubscribe()
-
-// Next: cherry
-// Next: banana
-// Next: apple
-// Completed
-```
+Reverse must buffer all elements before emitting the first one. Never use it on an unbounded or very large source.

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -205,7 +205,7 @@ observable.Subscribe(ro.OnNext(func(s string) {
 - **bytes** - Byte slice manipulation operators
 - **strings** - String manipulation operators (Capitalize, PascalCase, CamelCase, SnakeCase, etc.) with locale-aware WithLanguage variants
 - **strconv** - String conversion operators (FormatFloat, FormatInt, FormatUint, etc.)
-- **sort** - Sorting operators
+- **sort** - Sorting and reordering operators (Sort, SortFunc, SortStableFunc, Reverse)
 - **time** - Time manipulation operators (Add, AddDate, In, Format, Parse, ParseInLocation, StartOfDay)
 - **exp/simd** - SIMD-accelerated math operators (Add, Sub, Min, Max, Clamp...)
 

--- a/plugins/sort/README.md
+++ b/plugins/sort/README.md
@@ -1,6 +1,6 @@
 # Sort Plugin
 
-The sort plugin provides operators for sorting values in reactive streams. **⚠️ Warning: These operators load all values into memory before sorting, which is not recommended for large datasets.**
+The sort plugin provides operators for sorting and reordering values in reactive streams. **⚠️ Warning: These operators load all values into memory before emitting, which is not recommended for large datasets.**
 
 ## Installation
 
@@ -120,6 +120,33 @@ subscription := observable.Subscribe(ro.NewObserver(
 // Priority 1: First
 // Priority 1: Third
 // Priority 2: Second
+// Completed
+```
+
+### Reverse
+
+Buffers every item until the source completes, then re-emits them one by one in reverse order.
+
+```go
+observable := ro.Pipe1(
+    ro.Just(1, 2, 3, 4, 5),
+    rosort.Reverse[int](),
+)
+
+subscription := observable.Subscribe(ro.NewObserver(
+    func(value int) {
+        fmt.Printf("%d ", value)
+    },
+    func(err error) {
+        fmt.Printf("Error: %v\n", err)
+    },
+    func() {
+        fmt.Println("\nCompleted")
+    },
+))
+
+// Output:
+// 5 4 3 2 1
 // Completed
 ```
 

--- a/plugins/sort/operator.go
+++ b/plugins/sort/operator.go
@@ -111,9 +111,9 @@ func SortStableFunc[T comparable](cmp func(a, b T) int) func(ro.Observable[T]) r
 	}
 }
 
-// reversedItem keeps the context an item was emitted with, so replaying the
-// buffer in reverse order preserves the exact same context chain, item per item.
-type reversedItem[T any] struct {
+// bufferedItem keeps the context an item was emitted with, so replaying a
+// buffered item later preserves the exact same context chain, item per item.
+type bufferedItem[T any] struct {
 	ctx   context.Context
 	value T
 }
@@ -126,13 +126,13 @@ type reversedItem[T any] struct {
 func Reverse[T any]() func(ro.Observable[T]) ro.Observable[T] {
 	return func(source ro.Observable[T]) ro.Observable[T] {
 		return ro.NewUnsafeObservableWithContext(func(subscriberCtx context.Context, destination ro.Observer[T]) ro.Teardown {
-			buffer := []reversedItem[T]{}
+			buffer := []bufferedItem[T]{}
 
 			sub := source.SubscribeWithContext(
 				subscriberCtx,
 				ro.NewObserverWithContext(
 					func(ctx context.Context, value T) {
-						buffer = append(buffer, reversedItem[T]{ctx, value})
+						buffer = append(buffer, bufferedItem[T]{ctx, value})
 					},
 					destination.ErrorWithContext,
 					func(ctx context.Context) {

--- a/plugins/sort/operator.go
+++ b/plugins/sort/operator.go
@@ -110,3 +110,42 @@ func SortStableFunc[T comparable](cmp func(a, b T) int) func(ro.Observable[T]) r
 		})
 	}
 }
+
+// reversedItem keeps the context an item was emitted with, so replaying the
+// buffer in reverse order preserves the exact same context chain, item per item.
+type reversedItem[T any] struct {
+	ctx   context.Context
+	value T
+}
+
+// Reverse buffers every item emitted by the source Observable and, on completion,
+// re-emits them one by one in reverse order. Nothing is emitted before the source
+// completes.
+//
+// Warning: the whole stream is held in memory. Never use it on an unbounded source.
+func Reverse[T any]() func(ro.Observable[T]) ro.Observable[T] {
+	return func(source ro.Observable[T]) ro.Observable[T] {
+		return ro.NewUnsafeObservableWithContext(func(subscriberCtx context.Context, destination ro.Observer[T]) ro.Teardown {
+			buffer := []reversedItem[T]{}
+
+			sub := source.SubscribeWithContext(
+				subscriberCtx,
+				ro.NewObserverWithContext(
+					func(ctx context.Context, value T) {
+						buffer = append(buffer, reversedItem[T]{ctx, value})
+					},
+					destination.ErrorWithContext,
+					func(ctx context.Context) {
+						for i := len(buffer) - 1; i >= 0; i-- {
+							destination.NextWithContext(buffer[i].ctx, buffer[i].value)
+						}
+
+						destination.CompleteWithContext(ctx)
+					},
+				),
+			)
+
+			return sub.Unsubscribe
+		})
+	}
+}

--- a/plugins/sort/operator_example_test.go
+++ b/plugins/sort/operator_example_test.go
@@ -167,6 +167,25 @@ func ExampleSort_sortingStrings() {
 	// Completed
 }
 
+func ExampleReverse() {
+	// Buffer all items until completion, then re-emit them in reverse order
+	observable := ro.Pipe1(
+		ro.Just(1, 2, 3, 4, 5),
+		Reverse[int](),
+	)
+
+	subscription := observable.Subscribe(ro.PrintObserver[int]())
+	defer subscription.Unsubscribe()
+
+	// Output:
+	// Next: 5
+	// Next: 4
+	// Next: 3
+	// Next: 2
+	// Next: 1
+	// Completed
+}
+
 func ExampleSortFunc_sortingWithCustomStringLogic() {
 	// Sort strings by length, then alphabetically
 	observable := ro.Pipe1(

--- a/plugins/sort/operator_test.go
+++ b/plugins/sort/operator_test.go
@@ -16,6 +16,7 @@ package rosort
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -417,6 +418,142 @@ func toLower(s string) string {
 		}
 	}
 	return result
+}
+
+func TestReverse(t *testing.T) {
+	t.Parallel()
+	testWithTimeout(t, 100*time.Millisecond)
+	is := assert.New(t)
+
+	// Test with empty observable
+	values, err := ro.Collect(
+		Reverse[int]()(
+			ro.Just[int](),
+		),
+	)
+	is.Equal([]int{}, values)
+	is.NoError(err)
+
+	// Test with single value
+	values, err = ro.Collect(
+		Reverse[int]()(
+			ro.Just(42),
+		),
+	)
+	is.Equal([]int{42}, values)
+	is.NoError(err)
+
+	// Test with multiple values
+	values, err = ro.Collect(
+		Reverse[int]()(
+			ro.Just(1, 2, 3, 4, 5),
+		),
+	)
+	is.Equal([]int{5, 4, 3, 2, 1}, values)
+	is.NoError(err)
+
+	// Test with strings
+	valuesStr, err := ro.Collect(
+		Reverse[string]()(
+			ro.Just("apple", "banana", "cherry"),
+		),
+	)
+	is.Equal([]string{"cherry", "banana", "apple"}, valuesStr)
+	is.NoError(err)
+}
+
+func TestReverseWithError(t *testing.T) {
+	t.Parallel()
+	testWithTimeout(t, 100*time.Millisecond)
+	is := assert.New(t)
+
+	// Test with error observable
+	values, err := ro.Collect(
+		Reverse[int]()(
+			ro.Throw[int](assert.AnError),
+		),
+	)
+	is.Equal([]int{}, values)
+	is.EqualError(err, assert.AnError.Error())
+
+	// An error raised after some items were already buffered must not emit
+	// any of the buffered items.
+	values, err = ro.Collect(
+		Reverse[int]()(
+			ro.Pipe1(
+				ro.Just(1, 2, 3),
+				ro.ConcatWith(ro.Throw[int](assert.AnError)),
+			),
+		),
+	)
+	is.Equal([]int{}, values)
+	is.EqualError(err, assert.AnError.Error())
+}
+
+func TestReverseWithContext(t *testing.T) {
+	t.Parallel()
+	testWithTimeout(t, 100*time.Millisecond)
+	is := assert.New(t)
+
+	type ctxKey string
+	key := ctxKey("index")
+
+	var seen []int
+
+	values, err := ro.Collect(
+		ro.Pipe3(
+			ro.Just(10, 20, 30),
+			ro.MapIWithContext(func(ctx context.Context, v int, i int64) (context.Context, int) {
+				return context.WithValue(ctx, key, int(i)), v
+			}),
+			Reverse[int](),
+			ro.TapOnNextWithContext(func(ctx context.Context, _ int) {
+				index, _ := ctx.Value(key).(int)
+				seen = append(seen, index)
+			}),
+		),
+	)
+	is.Equal([]int{30, 20, 10}, values)
+	is.Equal([]int{2, 1, 0}, seen)
+	is.NoError(err)
+}
+
+func TestReverseWithContextCancellation(t *testing.T) {
+	t.Parallel()
+	testWithTimeout(t, 100*time.Millisecond)
+	is := assert.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	values, resultCtx, err := ro.CollectWithContext(ctx,
+		Reverse[int]()(
+			ro.Just(3, 1, 4, 1, 5, 9, 2, 6),
+		),
+	)
+	is.Equal([]int{6, 2, 9, 5, 1, 4, 1, 3}, values)
+	is.NoError(err)
+	is.NotNil(resultCtx)
+}
+
+func TestReverseEarlyUnsubscribe(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	var finalized int32
+
+	obs := ro.Pipe2(
+		ro.Never(),
+		ro.TapOnFinalize[struct{}](func() {
+			atomic.AddInt32(&finalized, 1)
+		}),
+		Reverse[struct{}](),
+	)
+
+	sub := obs.Subscribe(ro.OnNext(func(struct{}) {}))
+	sub.Unsubscribe()
+
+	is.EqualValues(1, atomic.LoadInt32(&finalized))
 }
 
 func testWithTimeout(t *testing.T, timeout time.Duration) {


### PR DESCRIPTION
## Summary
- Add `Reverse[T any]()` to the `sort` plugin: buffers every item emitted by the source until completion, then re-emits them one by one in reverse order.
- No `Backward`/`Reverse` operator existed anywhere in the repo before this change (core, plugins, or docs).
- Placed in `plugins/sort` rather than core, following the plugin's existing rationale (`Sort`/`SortFunc`/`SortStableFunc` already load the whole stream into memory before emitting).

## Test plan
- [x] `cd plugins/sort && go test -race ./...`
- [x] `go test -race $(go list -m) ./...` (workspace-wide; the only failure is pre-existing `plugins/proc` sandbox restrictions unrelated to this change)
- [x] `golangci-lint run ./...` in `plugins/sort` — no new issues introduced (verified against the `main` baseline)
- [x] `headercheck` — new files carry the Apache license header
- [x] Godoc `ExampleReverse` passes
