### PR TITLE
fix(plugins/sort,iter): preserve per-item context, stable sort, unsafe iter sources

### DIFF
--- a/docs/data/plugin-sort-reverse.md
+++ b/docs/data/plugin-sort-reverse.md
@@ -1,7 +1,7 @@
 ---
 name: Reverse
 slug: reverse
-sourceRef: plugins/sort/operator.go#L126
+sourceRef: plugins/sort/operator.go#L118
 type: plugin
 category: sort
 signatures:

--- a/docs/data/plugin-sort-sort.md
+++ b/docs/data/plugin-sort-sort.md
@@ -1,11 +1,11 @@
 ---
 name: Sort
 slug: sort
-sourceRef: plugins/sort/operator.go#L41
+sourceRef: plugins/sort/operator.go#L91
 type: plugin
 category: sort
 signatures:
-  - "func Sort[T cmp.Ordered](cmp func(a, b T) int)"
+  - "func Sort[T constraints.Ordered](cmp func(a, b T) int)"
 playUrl: https://go.dev/play/p/Jem9ufkfmNR
 variantHelpers:
   - plugin#sort#sort

--- a/docs/data/plugin-sort-sortfunc.md
+++ b/docs/data/plugin-sort-sortfunc.md
@@ -1,7 +1,7 @@
 ---
 name: SortFunc
 slug: sortfunc
-sourceRef: plugins/sort/operator.go#L66
+sourceRef: plugins/sort/operator.go#L99
 type: plugin
 category: sort
 signatures:

--- a/docs/data/plugin-sort-sortstablefunc.md
+++ b/docs/data/plugin-sort-sortstablefunc.md
@@ -1,7 +1,7 @@
 ---
 name: SortStableFunc
 slug: sortstablefunc
-sourceRef: plugins/sort/operator.go#L91
+sourceRef: plugins/sort/operator.go#L109
 type: plugin
 category: sort
 signatures:

--- a/plugins/iter/source.go
+++ b/plugins/iter/source.go
@@ -26,7 +26,7 @@ import (
 // FromSeq creates an observable from a Go sequence iterator.
 // Play: https://go.dev/play/p/Cq-cq_AR4Z6
 func FromSeq[T any](iterator iter.Seq[T]) ro.Observable[T] {
-	return ro.NewObservableWithContext(func(subscriberCtx context.Context, destination ro.Observer[T]) ro.Teardown {
+	return ro.NewUnsafeObservableWithContext(func(subscriberCtx context.Context, destination ro.Observer[T]) ro.Teardown {
 		for v := range iterator {
 			destination.NextWithContext(subscriberCtx, v)
 		}
@@ -38,7 +38,7 @@ func FromSeq[T any](iterator iter.Seq[T]) ro.Observable[T] {
 // FromSeq2 creates an observable from a Go sequence iterator with key-value pairs.
 // Play: https://go.dev/play/p/d-SZxjCKm9N
 func FromSeq2[K, V any](iterator iter.Seq2[K, V]) ro.Observable[lo.Tuple2[K, V]] {
-	return ro.NewObservableWithContext(func(subscriberCtx context.Context, destination ro.Observer[lo.Tuple2[K, V]]) ro.Teardown {
+	return ro.NewUnsafeObservableWithContext(func(subscriberCtx context.Context, destination ro.Observer[lo.Tuple2[K, V]]) ro.Teardown {
 		for k, v := range iterator {
 			destination.NextWithContext(subscriberCtx, lo.T2(k, v))
 		}

--- a/plugins/sort/operator.go
+++ b/plugins/sort/operator.go
@@ -36,86 +36,78 @@ import (
 //
 ////////////////////////////////////////////////////////////
 
-// Sort sorts the observable values using the provided comparison function.
-// Play: https://go.dev/play/p/3hL6m9jK5nV
-func Sort[T constraints.Ordered](cmp func(a, b T) int) func(ro.Observable[T]) ro.Observable[T] {
-	return func(source ro.Observable[T]) ro.Observable[T] {
-		return ro.NewObservableWithContext(func(subscriberCtx context.Context, destination ro.Observer[T]) ro.Teardown {
-			values, ctx, err := ro.CollectWithContext(subscriberCtx, source)
-			if err != nil {
-				destination.ErrorWithContext(ctx, err)
-				return nil
-			}
-
-			sort.Slice(values, func(i, j int) bool {
-				return cmp(values[i], values[j]) < 0
-			})
-
-			for _, value := range values {
-				destination.NextWithContext(ctx, value)
-			}
-			destination.CompleteWithContext(ctx)
-
-			return nil
-		})
-	}
-}
-
-// SortFunc sorts the observable values using the provided comparison function.
-// Play: https://go.dev/play/p/PzNTA9Vufy7
-func SortFunc[T comparable](cmp func(a, b T) int) func(ro.Observable[T]) ro.Observable[T] {
-	return func(source ro.Observable[T]) ro.Observable[T] {
-		return ro.NewObservableWithContext(func(subscriberCtx context.Context, destination ro.Observer[T]) ro.Teardown {
-			values, ctx, err := ro.CollectWithContext(subscriberCtx, source)
-			if err != nil {
-				destination.ErrorWithContext(ctx, err)
-				return nil
-			}
-
-			sort.Slice(values, func(i, j int) bool {
-				return cmp(values[i], values[j]) < 0
-			})
-
-			for _, value := range values {
-				destination.NextWithContext(ctx, value)
-			}
-			destination.CompleteWithContext(ctx)
-
-			return nil
-		})
-	}
-}
-
-// SortStableFunc sorts the observable values using the provided stable comparison function.
-// Play: https://go.dev/play/p/6b1tIxX9gfO
-func SortStableFunc[T comparable](cmp func(a, b T) int) func(ro.Observable[T]) ro.Observable[T] {
-	return func(source ro.Observable[T]) ro.Observable[T] {
-		return ro.NewObservableWithContext(func(subscriberCtx context.Context, destination ro.Observer[T]) ro.Teardown {
-			values, ctx, err := ro.CollectWithContext(subscriberCtx, source)
-			if err != nil {
-				destination.ErrorWithContext(ctx, err)
-				return nil
-			}
-
-			sort.Slice(values, func(i, j int) bool {
-				return cmp(values[i], values[j]) < 0
-			})
-
-			for _, value := range values {
-				destination.NextWithContext(ctx, value)
-			}
-			destination.CompleteWithContext(ctx)
-
-			return nil
-		})
-	}
-}
-
 // bufferedItem keeps the context an item was emitted with, so replaying a
 // buffered item later preserves the exact same context chain, item per item.
 type bufferedItem[T any] struct {
 	ctx   context.Context
 	value T
+}
+
+// sortBuffer buffers every item emitted by the source Observable and, on
+// completion, re-emits them sorted with cmp. Nothing is emitted before the
+// source completes. Each buffered item is replayed with the context it was
+// originally emitted with.
+func sortBuffer[T any](stable bool, cmp func(a, b T) int) func(ro.Observable[T]) ro.Observable[T] {
+	return func(source ro.Observable[T]) ro.Observable[T] {
+		return ro.NewUnsafeObservableWithContext(func(subscriberCtx context.Context, destination ro.Observer[T]) ro.Teardown {
+			buffer := []bufferedItem[T]{}
+
+			sub := source.SubscribeWithContext(
+				subscriberCtx,
+				ro.NewObserverWithContext(
+					func(ctx context.Context, value T) {
+						buffer = append(buffer, bufferedItem[T]{ctx, value})
+					},
+					destination.ErrorWithContext,
+					func(ctx context.Context) {
+						less := func(i, j int) bool {
+							return cmp(buffer[i].value, buffer[j].value) < 0
+						}
+
+						if stable {
+							sort.SliceStable(buffer, less)
+						} else {
+							sort.Slice(buffer, less)
+						}
+
+						for _, item := range buffer {
+							destination.NextWithContext(item.ctx, item.value)
+						}
+
+						destination.CompleteWithContext(ctx)
+					},
+				),
+			)
+
+			return sub.Unsubscribe
+		})
+	}
+}
+
+// Sort sorts the observable values using the provided comparison function.
+//
+// Warning: the whole stream is held in memory. Never use it on an unbounded source.
+// Play: https://go.dev/play/p/3hL6m9jK5nV
+func Sort[T constraints.Ordered](cmp func(a, b T) int) func(ro.Observable[T]) ro.Observable[T] {
+	return sortBuffer(false, cmp)
+}
+
+// SortFunc sorts the observable values using the provided comparison function.
+//
+// Warning: the whole stream is held in memory. Never use it on an unbounded source.
+// Play: https://go.dev/play/p/PzNTA9Vufy7
+func SortFunc[T comparable](cmp func(a, b T) int) func(ro.Observable[T]) ro.Observable[T] {
+	return sortBuffer(false, cmp)
+}
+
+// SortStableFunc sorts the observable values using the provided comparison function.
+// Unlike SortFunc, the relative order of equivalent elements (cmp(a, b) == 0) is
+// preserved.
+//
+// Warning: the whole stream is held in memory. Never use it on an unbounded source.
+// Play: https://go.dev/play/p/6b1tIxX9gfO
+func SortStableFunc[T comparable](cmp func(a, b T) int) func(ro.Observable[T]) ro.Observable[T] {
+	return sortBuffer(true, cmp)
 }
 
 // Reverse buffers every item emitted by the source Observable and, on completion,

--- a/plugins/sort/operator_test.go
+++ b/plugins/sort/operator_test.go
@@ -360,6 +360,54 @@ func TestSortWithContext(t *testing.T) {
 	is.NotNil(resultCtx)
 }
 
+func TestSortWithItemContext(t *testing.T) {
+	t.Parallel()
+	testWithTimeout(t, 100*time.Millisecond)
+	is := assert.New(t)
+
+	type ctxKey string
+	key := ctxKey("index")
+
+	var seen []int
+
+	values, err := ro.Collect(
+		ro.Pipe3(
+			ro.Just(30, 10, 20),
+			ro.MapIWithContext(func(ctx context.Context, v int, i int64) (context.Context, int) {
+				return context.WithValue(ctx, key, int(i)), v
+			}),
+			Sort(Compare[int]),
+			ro.TapOnNextWithContext(func(ctx context.Context, _ int) {
+				index, _ := ctx.Value(key).(int)
+				seen = append(seen, index)
+			}),
+		),
+	)
+	is.Equal([]int{10, 20, 30}, values)
+	is.Equal([]int{1, 2, 0}, seen)
+	is.NoError(err)
+}
+
+func TestSortEarlyUnsubscribe(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	var finalized int32
+
+	obs := ro.Pipe2(
+		ro.Never(),
+		ro.TapOnFinalize[struct{}](func() {
+			atomic.AddInt32(&finalized, 1)
+		}),
+		SortFunc(func(struct{}, struct{}) int { return 0 }),
+	)
+
+	sub := obs.Subscribe(ro.OnNext(func(struct{}) {}))
+	sub.Unsubscribe()
+
+	is.EqualValues(1, atomic.LoadInt32(&finalized))
+}
+
 func TestSortFuncWithContext(t *testing.T) {
 	t.Parallel()
 	testWithTimeout(t, 100*time.Millisecond)
@@ -396,6 +444,42 @@ func TestSortStableFuncWithContext(t *testing.T) {
 	is.Equal([]int{1, 1, 2, 3, 4, 5, 6, 9}, values)
 	is.Nil(err)
 	is.NotNil(resultCtx)
+}
+
+func TestSortStableFuncStability(t *testing.T) {
+	t.Parallel()
+	testWithTimeout(t, 100*time.Millisecond)
+	is := assert.New(t)
+
+	type stableItem struct {
+		key   int
+		order int
+	}
+
+	// Several items share the same key. A stable sort must preserve their
+	// original relative order (tracked here via the "order" field).
+	items := []stableItem{
+		{key: 1, order: 0},
+		{key: 2, order: 1},
+		{key: 1, order: 2},
+		{key: 2, order: 3},
+		{key: 1, order: 4},
+	}
+
+	values, err := ro.Collect(
+		SortStableFunc(func(a, b stableItem) int {
+			return Compare(a.key, b.key)
+		})(
+			ro.FromSlice(items),
+		),
+	)
+	is.NoError(err)
+
+	orders := make([]int, len(values))
+	for i, v := range values {
+		orders[i] = v.order
+	}
+	is.Equal([]int{0, 2, 4, 1, 3}, orders)
 }
 
 // Helper functions


### PR DESCRIPTION
## Summary

- `Sort`, `SortFunc` and `SortStableFunc` used `CollectWithContext`, which only tracks a single terminal `context.Context` — every re-emitted item lost the context it was originally emitted with.
- `SortStableFunc` called `sort.Slice` instead of `sort.SliceStable`, so it wasn't actually stable despite its name.
- Reworked the three operators around a shared internal `sortBuffer` helper, modeled after `Reverse`: items are buffered with their original context (`bufferedItem`, moved to the top of the file) and replayed with that same context after sorting.
- `plugins/iter`'s `FromSeq`/`FromSeq2` switched from `NewObservableWithContext` to `NewUnsafeObservableWithContext`: both iterate and emit synchronously from a single loop, so the safe observable's locking was unnecessary overhead.

## Behavior changes (plugins/sort)

| Before | After |
|---|---|
| All items re-emitted with a single terminal context | Each item re-emitted with its original context |
| `SortStableFunc` not actually stable | Actually stable (`sort.SliceStable`) |
| `nil` teardown (early unsubscribe has no upstream effect) | `sub.Unsubscribe` propagated |
| Blocking subscription (`Collect`'s internal `sub.Wait()`) | Non-blocking, like the other operators |
| Safe observable | Unsafe observable, like `Reverse` (replay is single-threaded from the `complete` callback) |

No public API changes in either plugin — signatures and sort semantics are unchanged.

## Test plan

Ran `go test -race` in `plugins/sort` and at the repo root, and `go test -race` with `GOWORK=off` in `plugins/iter` (excluded from `go.work`, requires Go 1.23+). Ran `golangci-lint --new-from-rev=HEAD` on both plugins and the repo root: no new issues. Added coverage in `plugins/sort` for per-item context propagation, `SortStableFunc` stability, and early-unsubscribe teardown.

Note: `plugins/iter`'s pre-existing `TestToSeq` hangs under `-race` on `main` too (confirmed independently) — unrelated to this change, not touched here. `plugins/proc` also has pre-existing sandbox-only failures (`/var/run/utmpx`, `exec /bin/ps` denied), unrelated to this PR.
