### PR TITLE
chore(deps): add cooldown to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,16 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
+    cooldown:
+      default-days: 7
     directory: /
     schedule:
       interval: monthly
 
   - package-ecosystem: gomod
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
     directories:
       - /
       - /ee/**
@@ -14,6 +19,9 @@ updates:
       interval: weekly
 
   - package-ecosystem: npm
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
     directory: /docs
     schedule:
       interval: monthly


### PR DESCRIPTION
Adds `cooldown` to each Dependabot update entry to avoid PR spam from freshly published versions.

- `default-days: 7` for all ecosystems
- `semver-major-days: 30` for ecosystems that support semver overrides

Security updates bypass the cooldown.